### PR TITLE
Implementiran role-based UI dizajn za dashboard

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,5 +1,15 @@
-import { TacticalDashboardOverview } from "@/components/tactical-dashboard-overview";
+import { RoleDashboard } from "@/components/dashboard/role-dashboard";
+import { normalizeDashboardRole } from "@/lib/role-dashboard-data";
 
-export default async function DashboardPage() {
-  return <TacticalDashboardOverview />;
+interface DashboardPageProps {
+  searchParams?: Promise<{
+    role?: string | string[];
+  }>;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const params = await searchParams;
+  const role = normalizeDashboardRole(params?.role);
+
+  return <RoleDashboard role={role} />;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3281,3 +3281,1322 @@ textarea:focus {
     text-align: left;
   }
 }
+
+.dashboard-page {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  background: #0a0a0a;
+}
+
+.role-dashboard {
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(211, 47, 47, 0.08), transparent 260px),
+    #0a0a0a;
+  color: #f9dcd9;
+}
+
+.role-dashboard-content {
+  display: grid;
+  gap: 24px;
+  width: min(1600px, 100%);
+  margin: 0 auto;
+  padding: 64px;
+}
+
+.role-dashboard-captain .role-dashboard-content,
+.role-dashboard-player .role-dashboard-content {
+  width: min(1440px, 100%);
+}
+
+.role-dashboard-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 76px;
+  padding: 14px 64px;
+  border-bottom: 1px solid rgba(171, 137, 133, 0.36);
+  background: rgba(30, 15, 14, 0.9);
+  backdrop-filter: blur(14px);
+}
+
+.role-topbar-left,
+.role-topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  min-width: 0;
+}
+
+.role-live-chip,
+.role-rank-chip,
+.role-active-context strong {
+  border: 1px solid rgba(171, 137, 133, 0.42);
+  background: rgba(67, 48, 46, 0.55);
+}
+
+.role-live-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  color: #7bd1f8;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.role-live-chip span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #7bd1f8;
+  box-shadow: 0 0 0 5px rgba(123, 209, 248, 0.1);
+}
+
+.role-active-context {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.role-active-context span,
+.role-rank-chip span,
+.role-kpi-heading span,
+.role-panel-header p,
+.role-status-chip,
+.role-hero-kicker,
+.role-hero-label-row span,
+.role-hero-form > span,
+.role-section-heading span,
+.role-performance-card > span,
+.role-mini-card span,
+.role-public-card > p:first-of-type,
+.role-organizer-signals span,
+.role-data-table th {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.role-active-context span {
+  color: #e4beba;
+}
+
+.role-active-context strong {
+  min-width: 0;
+  padding: 4px 10px;
+  border-radius: 4px;
+  color: #fff2f0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.role-rank-chip {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 0 8px;
+  align-items: center;
+  min-height: 42px;
+  padding: 7px 12px;
+  border-color: rgba(233, 193, 118, 0.38);
+  border-radius: 4px;
+  color: #e9c176;
+}
+
+.role-rank-chip svg {
+  grid-row: span 2;
+}
+
+.role-rank-chip span {
+  color: #e4beba;
+  font-size: 0.62rem;
+  line-height: 1;
+}
+
+.role-rank-chip strong {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.role-icon-button,
+.role-avatar {
+  display: inline-grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(171, 137, 133, 0.42);
+  border-radius: 8px;
+  background: rgba(18, 18, 18, 0.82);
+  color: #f9dcd9;
+}
+
+.role-avatar {
+  border-radius: 999px;
+  color: #7bd1f8;
+}
+
+.role-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 46px;
+  padding: 11px 18px;
+  border: 1px solid rgba(171, 137, 133, 0.42);
+  border-radius: 4px;
+  background: rgba(67, 48, 46, 0.72);
+  color: #f9dcd9;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-align: center;
+}
+
+.role-action-primary {
+  border-color: rgba(211, 47, 47, 0.85);
+  background: #d32f2f;
+  color: #fff2f0;
+}
+
+.role-action-secondary {
+  background: transparent;
+  color: #f9dcd9;
+}
+
+.role-action-button.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.role-action-button:hover:not(.is-disabled) {
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.role-kpi-grid {
+  display: grid;
+  gap: 24px;
+}
+
+.role-kpi-four {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.role-kpi-five {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.role-kpi-three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.role-kpi-card,
+.role-panel,
+.role-mini-card,
+.role-performance-card,
+.role-public-card {
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 8px;
+  background: rgba(18, 18, 18, 0.74);
+  backdrop-filter: blur(12px);
+}
+
+.role-kpi-card {
+  display: grid;
+  align-content: space-between;
+  min-height: 132px;
+  padding: 24px;
+  border-left: 4px solid #ffb3ac;
+}
+
+.role-kpi-card:hover,
+.role-panel:hover,
+.role-mini-card:hover,
+.role-performance-card:hover {
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.role-kpi-heading,
+.role-panel-header,
+.role-hero-meta,
+.role-section-heading,
+.role-table-actions,
+.role-organizer-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.role-kpi-heading {
+  color: #e4beba;
+}
+
+.role-kpi-heading svg,
+.role-tone-red svg {
+  color: #ffb3ac;
+}
+
+.role-tone-gold svg {
+  color: #e9c176;
+}
+
+.role-tone-cyan svg {
+  color: #7bd1f8;
+}
+
+.role-tone-green svg {
+  color: #6ee7a8;
+}
+
+.role-kpi-value-row {
+  display: flex;
+  align-items: end;
+  gap: 18px;
+  margin-top: 18px;
+}
+
+.role-kpi-value-row strong {
+  color: #f9dcd9;
+  font-size: 3.2rem;
+  font-weight: 900;
+  line-height: 0.9;
+}
+
+.role-progress-track {
+  flex: 1;
+  height: 7px;
+  margin-bottom: 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #43302e;
+}
+
+.role-progress-track span {
+  display: block;
+  height: 100%;
+  background: #ffb3ac;
+}
+
+.role-tone-gold.role-kpi-card {
+  border-left-color: #e9c176;
+}
+
+.role-tone-gold .role-progress-track span {
+  background: #e9c176;
+}
+
+.role-tone-cyan.role-kpi-card {
+  border-left-color: #7bd1f8;
+}
+
+.role-tone-cyan .role-progress-track span {
+  background: #7bd1f8;
+}
+
+.role-tone-green .role-progress-track span {
+  background: #6ee7a8;
+}
+
+.role-hero {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(171, 137, 133, 0.44);
+  border-radius: 12px;
+  background:
+    linear-gradient(90deg, rgba(30, 15, 14, 0.96), rgba(30, 15, 14, 0.65), rgba(10, 10, 10, 0.4)),
+    radial-gradient(circle at 70% 8%, rgba(123, 209, 248, 0.16), transparent 30%),
+    radial-gradient(circle at 28% 20%, rgba(211, 47, 47, 0.25), transparent 34%),
+    #121212;
+}
+
+.role-hero::after {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(90deg, transparent 0 88%, rgba(123, 209, 248, 0.08)),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0 1px, transparent 1px 86px);
+  content: "";
+  opacity: 0.55;
+}
+
+.role-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.role-captain-hero {
+  display: grid;
+  gap: 28px;
+  min-height: 430px;
+  padding: 92px 64px 54px;
+}
+
+.role-hero-kicker {
+  display: inline-flex;
+  width: fit-content;
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 179, 172, 0.48);
+  border-radius: 3px;
+  background: rgba(211, 47, 47, 0.16);
+  color: #ffb3ac;
+}
+
+.role-hero h1 {
+  margin-top: 14px;
+  color: #f9dcd9;
+  font-size: 4.6rem;
+  font-weight: 900;
+  line-height: 0.92;
+  text-transform: uppercase;
+}
+
+.role-hero-status {
+  margin-top: 16px;
+  color: #f9dcd9;
+  font-size: 1.55rem;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.role-hero-status strong {
+  color: #7bd1f8;
+}
+
+.role-hero-form {
+  display: grid;
+  justify-items: end;
+  gap: 10px;
+}
+
+.role-captain-hero .role-hero-form {
+  position: absolute;
+  top: 174px;
+  right: 64px;
+}
+
+.role-hero-form > span {
+  color: #e4beba;
+}
+
+.role-form-chips {
+  display: flex;
+  gap: 6px;
+}
+
+.role-form-chips span {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 3px;
+  font-size: 0.85rem;
+  font-weight: 900;
+}
+
+.role-form-chips .is-win {
+  border: 1px solid rgba(38, 215, 110, 0.66);
+  background: rgba(38, 215, 110, 0.18);
+  color: #26d76e;
+}
+
+.role-form-chips .is-loss {
+  border: 1px solid rgba(255, 179, 172, 0.56);
+  background: rgba(211, 47, 47, 0.18);
+  color: #ffb3ac;
+}
+
+.role-hero-meta {
+  align-items: stretch;
+  margin-top: auto;
+  padding-top: 38px;
+  border-top: 1px solid rgba(171, 137, 133, 0.28);
+}
+
+.role-hero-meta article {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  min-width: 0;
+}
+
+.role-hero-meta p,
+.role-data-table td span,
+.role-mini-card p,
+.role-performance-card p,
+.role-panel-header p,
+.role-alert p,
+.role-captain-channel p,
+.role-public-card p {
+  color: #e4beba;
+}
+
+.role-hero-meta p {
+  margin-bottom: 6px;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.role-hero-meta strong {
+  color: #fff2f0;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+}
+
+.role-opponent-code,
+.role-team-cell em,
+.role-hero-cell em {
+  display: inline-grid;
+  place-items: center;
+  width: 54px;
+  height: 54px;
+  border: 1px solid rgba(171, 137, 133, 0.42);
+  border-radius: 4px;
+  background: rgba(67, 48, 46, 0.7);
+  color: #f9dcd9;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.role-briefing-button {
+  min-width: 260px;
+  border: 1px solid rgba(255, 179, 172, 0.54);
+  border-radius: 3px;
+  background: transparent;
+  color: #f9dcd9;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.role-captain-grid,
+.role-organizer-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 0.95fr);
+  gap: 32px;
+}
+
+.role-captain-main,
+.role-side-stack,
+.role-organizer-main {
+  display: grid;
+  gap: 24px;
+  align-content: start;
+}
+
+.role-panel {
+  min-width: 0;
+  padding: 0;
+}
+
+.role-panel-header {
+  min-height: 68px;
+  padding: 22px 28px;
+  border-bottom: 1px solid rgba(171, 137, 133, 0.32);
+}
+
+.role-panel-header h2,
+.role-section-heading h2 {
+  color: #f9dcd9;
+  font-size: 1.55rem;
+  font-weight: 900;
+  letter-spacing: 0.01em;
+}
+
+.role-panel-header p {
+  margin-bottom: 6px;
+}
+
+.role-view-all {
+  color: #f9dcd9;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.role-table-wrap {
+  overflow-x: auto;
+}
+
+.role-data-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+}
+
+.role-data-table th,
+.role-data-table td {
+  padding: 20px 28px;
+  border-bottom: 1px solid rgba(171, 137, 133, 0.18);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.role-data-table th {
+  color: #e4beba;
+  background: rgba(67, 48, 46, 0.35);
+}
+
+.role-data-table td {
+  color: #f9dcd9;
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+}
+
+.role-data-table td strong {
+  display: block;
+  color: #f9dcd9;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+.role-team-cell,
+.role-hero-cell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.role-team-cell em,
+.role-hero-cell em {
+  width: 36px;
+  height: 36px;
+  font-size: 0.7rem;
+}
+
+.role-status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  padding: 4px 8px;
+  border: 1px solid rgba(171, 137, 133, 0.38);
+  border-radius: 3px;
+  color: #e4beba;
+  font-size: 0.62rem;
+}
+
+.role-status-chip.role-tone-red {
+  border-color: rgba(255, 179, 172, 0.7);
+  color: #ffb3ac;
+}
+
+.role-status-chip.role-tone-gold {
+  border-color: rgba(233, 193, 118, 0.68);
+  color: #e9c176;
+}
+
+.role-status-chip.role-tone-cyan {
+  border-color: rgba(123, 209, 248, 0.72);
+  color: #7bd1f8;
+}
+
+.role-status-chip.role-tone-green {
+  border-color: rgba(38, 215, 110, 0.72);
+  color: #26d76e;
+}
+
+.role-quick-actions {
+  display: grid;
+  gap: 14px;
+  padding: 28px;
+}
+
+.role-quick-actions .role-action-button {
+  justify-content: flex-start;
+  min-height: 68px;
+  padding: 16px 20px;
+  font-size: 1rem;
+}
+
+.role-roster-strip {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.role-roster-strip article {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  padding: 28px;
+  border-right: 1px solid rgba(171, 137, 133, 0.18);
+}
+
+.role-roster-strip article:last-child {
+  border-right: 0;
+}
+
+.role-roster-strip strong,
+.role-player-roster strong,
+.role-squad-grid strong,
+.role-captain-channel strong {
+  display: block;
+  color: #f9dcd9;
+}
+
+.role-roster-strip span:not(.role-player-avatar),
+.role-player-roster span:not(.role-player-avatar):not(.role-status-chip) {
+  display: block;
+  margin-top: 3px;
+  color: #e4beba;
+  font-size: 0.78rem;
+}
+
+.role-player-avatar {
+  display: inline-grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(123, 209, 248, 0.45);
+  border-radius: 4px;
+  background:
+    linear-gradient(145deg, rgba(123, 209, 248, 0.16), rgba(211, 47, 47, 0.16)),
+    rgba(18, 18, 18, 0.9);
+  color: #7bd1f8;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+.role-mini-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.role-mini-card {
+  display: grid;
+  gap: 10px;
+  min-height: 150px;
+  padding: 28px;
+}
+
+.role-mini-card strong {
+  color: #f9dcd9;
+  font-size: 2.55rem;
+  line-height: 1;
+}
+
+.role-alert-list {
+  display: grid;
+  gap: 14px;
+  padding: 28px;
+}
+
+.role-alert {
+  padding: 18px 20px;
+  border-left: 4px solid #ffb3ac;
+  border-radius: 4px;
+  background: rgba(67, 48, 46, 0.32);
+}
+
+.role-alert.role-tone-gold {
+  border-left-color: #e9c176;
+}
+
+.role-alert strong {
+  display: block;
+  margin-bottom: 7px;
+  color: #f9dcd9;
+}
+
+.role-captain-channel {
+  display: grid;
+  gap: 10px;
+  padding: 28px;
+}
+
+.role-player-hero {
+  display: grid;
+  min-height: 320px;
+  padding: 54px 56px;
+}
+
+.role-player-hero-copy {
+  max-width: 760px;
+}
+
+.role-hero-label-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.role-hero-label-row span:last-child {
+  color: #ffb3ac;
+}
+
+.role-player-hero h1 {
+  margin-top: 22px;
+  font-size: 4rem;
+  text-transform: none;
+}
+
+.role-player-hero p {
+  max-width: 720px;
+  margin-top: 14px;
+  color: #f9dcd9;
+  font-size: 1.08rem;
+  line-height: 1.65;
+}
+
+.role-player-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 30px;
+}
+
+.role-player-form {
+  position: absolute;
+  top: 50%;
+  right: 56px;
+  transform: translateY(-50%);
+}
+
+.role-player-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 32px;
+  align-items: start;
+}
+
+.role-section-heading {
+  margin-bottom: 18px;
+}
+
+.role-section-heading h2 {
+  color: #ffb3ac;
+}
+
+.role-section-heading span {
+  color: #e4beba;
+}
+
+.role-performance-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.role-performance-card {
+  display: grid;
+  align-content: space-between;
+  min-height: 154px;
+  padding: 26px;
+}
+
+.role-performance-card.is-featured {
+  min-height: 190px;
+}
+
+.role-performance-card strong {
+  color: #f9dcd9;
+  font-size: 2rem;
+  line-height: 1.12;
+}
+
+.role-performance-card.role-tone-gold {
+  border-color: rgba(233, 193, 118, 0.42);
+}
+
+.role-player-roster {
+  display: grid;
+  gap: 20px;
+  padding: 28px;
+}
+
+.role-player-roster article {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+}
+
+.role-player-roster-panel .role-action-button {
+  width: calc(100% - 56px);
+  margin: 0 28px 28px;
+}
+
+.role-table-actions button,
+.role-load-more,
+.role-squad-grid button {
+  min-height: 32px;
+  padding: 6px 14px;
+  border: 1px solid rgba(171, 137, 133, 0.46);
+  border-radius: 2px;
+  background: transparent;
+  color: #f9dcd9;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.role-match-log-table {
+  min-width: 980px;
+}
+
+.role-load-more {
+  width: 100%;
+  min-height: 56px;
+  border-width: 0;
+  border-top: 1px solid rgba(171, 137, 133, 0.32);
+}
+
+.role-organizer-hero {
+  min-height: 420px;
+  padding: 58px;
+}
+
+.role-organizer-hero-copy {
+  max-width: 760px;
+}
+
+.role-organizer-hero h1 {
+  font-size: 4rem;
+}
+
+.role-organizer-hero p {
+  margin-top: 14px;
+  color: #f9dcd9;
+  font-size: 1.08rem;
+  line-height: 1.65;
+}
+
+.role-organizer-signals {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 32px;
+  margin-top: 34px;
+}
+
+.role-organizer-signals article {
+  min-width: 150px;
+  padding-right: 32px;
+  border-right: 1px solid rgba(171, 137, 133, 0.24);
+}
+
+.role-organizer-signals article:last-child {
+  border-right: 0;
+}
+
+.role-organizer-signals strong {
+  display: block;
+  margin-top: 8px;
+  color: #f9dcd9;
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.role-organizer-actions {
+  justify-content: flex-start;
+  margin-top: 34px;
+}
+
+.role-organizer-main .role-panel-header {
+  border-bottom: 0;
+}
+
+.role-organizer-actions-list .role-action-button {
+  background: rgba(18, 18, 18, 0.84);
+}
+
+.role-squad-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 24px;
+  padding: 0 28px 28px;
+}
+
+.role-squad-grid article {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  min-height: 230px;
+  padding: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 8px;
+  background: rgba(18, 18, 18, 0.72);
+  text-align: center;
+}
+
+.role-squad-grid .role-player-avatar {
+  width: 64px;
+  height: 64px;
+  border-color: rgba(255, 179, 172, 0.35);
+  color: #ffb3ac;
+}
+
+.role-squad-grid button {
+  width: 100%;
+  margin-top: auto;
+}
+
+.role-pipeline-list {
+  display: grid;
+  gap: 16px;
+  padding: 28px;
+}
+
+.role-pipeline-list article {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.role-pipeline-list span {
+  color: #f9dcd9;
+}
+
+.role-pipeline-list strong {
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.role-tone-text-cyan {
+  color: #7bd1f8;
+}
+
+.role-tone-text-gold {
+  color: #e9c176;
+}
+
+.role-tone-text-red {
+  color: #ffb3ac;
+}
+
+.role-tone-text-green {
+  color: #6ee7a8;
+}
+
+.role-public-shell {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  padding: 64px;
+}
+
+.role-public-card {
+  display: grid;
+  justify-items: center;
+  max-width: 720px;
+  padding: 54px;
+  text-align: center;
+}
+
+.role-public-icon {
+  display: inline-grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  margin-bottom: 24px;
+  border: 1px solid rgba(255, 179, 172, 0.42);
+  border-radius: 12px;
+  background: rgba(211, 47, 47, 0.14);
+  color: #ffb3ac;
+}
+
+.role-public-card h1 {
+  margin-top: 12px;
+  color: #f9dcd9;
+  font-size: 2.4rem;
+  line-height: 1.1;
+}
+
+.role-public-card p:not(.role-hero-kicker) {
+  max-width: 560px;
+  margin-top: 18px;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.role-public-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px;
+  margin-top: 30px;
+}
+
+@media (max-width: 1280px) {
+  .role-dashboard-content,
+  .role-dashboard-topbar {
+    padding-right: 32px;
+    padding-left: 32px;
+  }
+
+  .role-kpi-four,
+  .role-kpi-five,
+  .role-performance-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .role-captain-grid,
+  .role-organizer-grid,
+  .role-player-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .role-roster-strip,
+  .role-squad-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .role-captain-hero .role-hero-form,
+  .role-player-form {
+    position: static;
+    justify-items: start;
+    transform: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .role-dashboard-topbar,
+  .role-topbar-left,
+  .role-topbar-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .role-dashboard-topbar {
+    position: static;
+    padding: 18px;
+  }
+
+  .role-topbar-actions {
+    width: 100%;
+    gap: 12px;
+  }
+
+  .role-topbar-actions .role-action-button {
+    width: 100%;
+  }
+
+  .role-dashboard-content,
+  .role-public-shell {
+    padding: 20px;
+  }
+
+  .role-captain-hero,
+  .role-player-hero,
+  .role-organizer-hero {
+    min-height: auto;
+    padding: 28px;
+  }
+
+  .role-hero h1,
+  .role-player-hero h1,
+  .role-organizer-hero h1 {
+    font-size: 2.65rem;
+  }
+
+  .role-hero-meta,
+  .role-organizer-actions,
+  .role-public-actions {
+    display: grid;
+  }
+
+  .role-briefing-button,
+  .role-organizer-actions .role-action-button {
+    width: 100%;
+    min-height: 48px;
+  }
+
+  .role-kpi-four,
+  .role-kpi-five,
+  .role-mini-card-grid,
+  .role-performance-grid,
+  .role-roster-strip,
+  .role-squad-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .role-roster-strip article {
+    border-right: 0;
+    border-bottom: 1px solid rgba(171, 137, 133, 0.18);
+  }
+
+  .role-player-roster article {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .role-player-roster .role-status-chip {
+    grid-column: 2;
+    justify-self: start;
+  }
+}
+
+@media (min-width: 861px) {
+  .role-dashboard-captain .role-dashboard-content,
+  .role-dashboard-organizer .role-dashboard-content {
+    width: 100%;
+    max-width: none;
+    margin-right: auto;
+    margin-left: 0;
+    padding: 54px 64px 64px;
+  }
+
+  .role-dashboard-captain .role-dashboard-content {
+    gap: 20px;
+  }
+
+  .role-dashboard-organizer .role-dashboard-content {
+    gap: 22px;
+  }
+
+  .role-dashboard-captain .role-kpi-grid,
+  .role-dashboard-organizer .role-kpi-grid {
+    gap: 22px;
+  }
+
+  .role-dashboard-captain .role-kpi-card,
+  .role-dashboard-organizer .role-kpi-card {
+    min-height: 116px;
+    padding: 22px 24px;
+  }
+
+  .role-dashboard-captain .role-kpi-value-row,
+  .role-dashboard-organizer .role-kpi-value-row {
+    margin-top: 14px;
+  }
+
+  .role-dashboard-captain .role-hero {
+    margin-top: 4px;
+  }
+
+  .role-captain-hero {
+    min-height: 398px;
+    padding: 86px 54px 48px;
+  }
+
+  .role-captain-hero .role-hero-form {
+    top: 162px;
+    right: 54px;
+  }
+
+  .role-captain-grid,
+  .role-organizer-grid {
+    align-items: start;
+    gap: 26px;
+  }
+
+  .role-captain-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(300px, 0.96fr);
+  }
+
+  .role-organizer-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(300px, 0.9fr);
+  }
+
+  .role-captain-main,
+  .role-organizer-main,
+  .role-side-stack {
+    gap: 20px;
+  }
+
+  .role-panel-header {
+    min-height: 58px;
+    padding: 18px 26px;
+  }
+
+  .role-dashboard-captain .role-data-table th,
+  .role-dashboard-captain .role-data-table td,
+  .role-dashboard-organizer .role-data-table th,
+  .role-dashboard-organizer .role-data-table td {
+    padding: 17px 26px;
+  }
+
+  .role-quick-actions {
+    gap: 12px;
+    padding: 22px 26px;
+  }
+
+  .role-dashboard-captain .role-quick-actions .role-action-button {
+    min-height: 62px;
+  }
+
+  .role-dashboard-organizer .role-quick-actions .role-action-button {
+    min-height: 54px;
+  }
+
+  .role-alert-list,
+  .role-pipeline-list {
+    gap: 12px;
+    padding: 22px 26px;
+  }
+
+  .role-alert {
+    padding: 16px 18px;
+  }
+
+  .role-roster-strip article {
+    padding: 24px 22px;
+  }
+
+  .role-mini-card-grid {
+    gap: 20px;
+  }
+
+  .role-mini-card {
+    min-height: 132px;
+    padding: 24px 26px;
+  }
+
+  .role-organizer-hero {
+    min-height: 390px;
+    padding: 52px 56px;
+  }
+
+  .role-organizer-hero + .role-kpi-grid {
+    margin-top: 10px;
+  }
+
+  .role-organizer-signals {
+    gap: 28px;
+    margin-top: 28px;
+  }
+
+  .role-organizer-actions {
+    margin-top: 28px;
+  }
+
+  .role-squad-grid {
+    gap: 20px;
+    padding: 0 26px 26px;
+  }
+
+  .role-squad-grid article {
+    min-height: 210px;
+    padding: 24px;
+  }
+}
+
+@media (min-width: 1281px) {
+  .role-dashboard-captain .role-dashboard-content,
+  .role-dashboard-organizer .role-dashboard-content {
+    padding-right: 70px;
+    padding-left: 70px;
+  }
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -30,6 +30,7 @@ const navItems = [
 export function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? "mock data";
+  const isRoleDashboard = pathname.startsWith("/dashboard");
 
   return (
     <div className="app-shell">
@@ -75,47 +76,51 @@ export function AppShell({ children }: { children: ReactNode }) {
       </aside>
 
       <div className="main-area">
-        <header className="topbar ops-panel">
-          <div className="topbar-title">
-            <span className="topbar-kicker">DOTAOPS COMMAND CENTER</span>
-            <strong>Tournament operations and analytics platform</strong>
-          </div>
-
-          <div className="topbar-actions" aria-label="Application status and actions">
-            <div className="topbar-status-segment">
-              <RadioTower size={16} />
-              <span>OPS STATUS</span>
-              <strong>ONLINE</strong>
+        {isRoleDashboard ? null : (
+          <header className="topbar ops-panel">
+            <div className="topbar-title">
+              <span className="topbar-kicker">DOTAOPS COMMAND CENTER</span>
+              <strong>Tournament operations and analytics platform</strong>
             </div>
 
-            <div className="topbar-status-segment topbar-rank-segment">
-              <Shield size={16} />
-              <span>RANK</span>
-              <strong>IMMORTAL</strong>
+            <div className="topbar-actions" aria-label="Application status and actions">
+              <div className="topbar-status-segment">
+                <RadioTower size={16} />
+                <span>OPS STATUS</span>
+                <strong>ONLINE</strong>
+              </div>
+
+              <div className="topbar-status-segment topbar-rank-segment">
+                <Shield size={16} />
+                <span>RANK</span>
+                <strong>IMMORTAL</strong>
+              </div>
+
+              <button className="topbar-icon-button" type="button" aria-label="Notifications">
+                <Bell size={17} />
+              </button>
+
+              <div className="topbar-profile" aria-label="User profile">
+                <span className="topbar-avatar" aria-hidden="true">
+                  <UserRound size={16} />
+                </span>
+                <span>
+                  <strong>SOLO_TACTICIAN</strong>
+                  <small>Organizer</small>
+                </span>
+              </div>
+
+              <Link className="button button-primary ops-button-primary topbar-primary-action" href="/organizator">
+                <Plus size={18} />
+                <span>New Tournament</span>
+              </Link>
             </div>
+          </header>
+        )}
 
-            <button className="topbar-icon-button" type="button" aria-label="Notifications">
-              <Bell size={17} />
-            </button>
-
-            <div className="topbar-profile" aria-label="User profile">
-              <span className="topbar-avatar" aria-hidden="true">
-                <UserRound size={16} />
-              </span>
-              <span>
-                <strong>SOLO_TACTICIAN</strong>
-                <small>Organizer</small>
-              </span>
-            </div>
-
-            <Link className="button button-primary ops-button-primary topbar-primary-action" href="/organizator">
-              <Plus size={18} />
-              <span>New Tournament</span>
-            </Link>
-          </div>
-        </header>
-
-        <main className="page">{children}</main>
+        <main className={classNames("page", isRoleDashboard && "dashboard-page")}>
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/frontend/src/components/dashboard/captain-dashboard-view.tsx
+++ b/frontend/src/components/dashboard/captain-dashboard-view.tsx
@@ -1,0 +1,160 @@
+import { Clock3, Gamepad2 } from "lucide-react";
+
+import {
+  AlertsPanel,
+  DashboardTopbar,
+  FormChips,
+  PlayerAvatar,
+  RoleActionButton,
+  RoleKpiGrid,
+  RolePanel,
+  StatusChip
+} from "@/components/dashboard/role-dashboard-primitives";
+import { captainDashboardData as data } from "@/lib/role-dashboard-data";
+
+export function CaptainDashboardView() {
+  return (
+    <div className="role-dashboard role-dashboard-captain">
+      <DashboardTopbar
+        activeLabel="Active"
+        activeValue={data.topbar.activeTeam}
+        action={data.topbar.primaryAction}
+        rank={data.topbar.rank}
+      />
+
+      <div className="role-dashboard-content">
+        <RoleKpiGrid items={data.kpis} />
+
+        <section className="role-hero role-captain-hero">
+          <div className="role-hero-content">
+            <span className="role-hero-kicker">Current Active Roster</span>
+            <h1>{data.hero.team}</h1>
+            <p className="role-hero-status">
+              Captain Status: <strong>{data.hero.status}</strong>
+            </p>
+          </div>
+
+          <div className="role-hero-form">
+            <span>Recent Form</span>
+            <FormChips values={data.hero.recentForm} />
+          </div>
+
+          <div className="role-hero-meta">
+            <article>
+              <span className="role-opponent-code">{data.hero.opponentCode}</span>
+              <div>
+                <p>Next Match vs</p>
+                <strong>{data.hero.opponent}</strong>
+              </div>
+            </article>
+            <article>
+              <Clock3 size={26} />
+              <div>
+                <p>Scheduled Start</p>
+                <strong>{data.hero.scheduledStart}</strong>
+              </div>
+            </article>
+            <button className="role-briefing-button" type="button">
+              Pre-Match Briefing
+            </button>
+          </div>
+        </section>
+
+        <section className="role-captain-grid">
+          <div className="role-captain-main">
+            <RolePanel
+              title="Upcoming Matches"
+              action={<span className="role-view-all">View all</span>}
+            >
+              <div className="role-table-wrap">
+                <table className="role-data-table">
+                  <thead>
+                    <tr>
+                      <th>Tournament</th>
+                      <th>Opponent</th>
+                      <th>Time</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.upcomingMatches.map((match) => (
+                      <tr key={`${match.tournament}-${match.opponent}`}>
+                        <td>
+                          <strong>{match.tournament}</strong>
+                          <span>{match.detail}</span>
+                        </td>
+                        <td>
+                          <span className="role-team-cell">
+                            <em>{match.opponentCode}</em>
+                            {match.opponent}
+                          </span>
+                        </td>
+                        <td>{match.time}</td>
+                        <td>
+                          <StatusChip tone={match.status === "ready" ? "cyan" : match.status === "queued" ? "gold" : "muted"}>
+                            {match.status}
+                          </StatusChip>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </RolePanel>
+
+            <RolePanel title="Team Roster">
+              <div className="role-roster-strip">
+                {data.roster.map((player) => (
+                  <article key={player.id}>
+                    <PlayerAvatar player={player} />
+                    <div>
+                      <strong>{player.name}</strong>
+                      <span>
+                        {player.role} / {player.hero}
+                      </span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </RolePanel>
+
+            <section className="role-mini-card-grid">
+              {data.performance.map((item) => {
+                const Icon = item.icon;
+
+                return (
+                  <article className={`role-mini-card role-tone-${item.tone}`} key={item.label}>
+                    <Icon size={18} />
+                    <span>{item.label}</span>
+                    <strong>{item.value}</strong>
+                    <p>{item.detail}</p>
+                  </article>
+                );
+              })}
+            </section>
+          </div>
+
+          <aside className="role-side-stack">
+            <RolePanel title="Quick Actions">
+              <div className="role-quick-actions">
+                {data.quickActions.map((action) => (
+                  <RoleActionButton action={action} key={action.label} />
+                ))}
+              </div>
+            </RolePanel>
+
+            <AlertsPanel alerts={data.alerts} />
+
+            <RolePanel title="Captain Channel" eyebrow="Private workspace">
+              <div className="role-captain-channel">
+                <Gamepad2 size={20} />
+                <strong>Draft prep room ready</strong>
+                <p>Briefing actions are placeholders until match workflows are wired to backend data.</p>
+              </div>
+            </RolePanel>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/organizer-dashboard-view.tsx
+++ b/frontend/src/components/dashboard/organizer-dashboard-view.tsx
@@ -1,0 +1,158 @@
+import Link from "next/link";
+
+import {
+  AlertsPanel,
+  DashboardTopbar,
+  PlayerAvatar,
+  RoleActionButton,
+  RoleKpiGrid,
+  RolePanel,
+  StatusChip
+} from "@/components/dashboard/role-dashboard-primitives";
+import { organizerDashboardData as data } from "@/lib/role-dashboard-data";
+
+export function OrganizerDashboardView() {
+  return (
+    <div className="role-dashboard role-dashboard-organizer">
+      <DashboardTopbar
+        activeLabel="Active Tournament"
+        activeValue={data.topbar.activeTournament}
+        action={data.topbar.primaryAction}
+      />
+
+      <div className="role-dashboard-content">
+        <section className="role-hero role-organizer-hero">
+          <div className="role-organizer-hero-copy">
+            <div className="role-hero-label-row">
+              <span className="role-hero-kicker">Pro Series</span>
+              <span>Live Feed: Arena A-01</span>
+            </div>
+            <h1>{data.hero.title}</h1>
+            <p>{data.hero.description}</p>
+
+            <div className="role-organizer-signals">
+              <article>
+                <span>Registered Teams</span>
+                <strong>{data.hero.registeredTeams}</strong>
+              </article>
+              <article>
+                <span>Match Integrity</span>
+                <strong>{data.hero.integrity}</strong>
+              </article>
+              <article>
+                <span>Tournament Status</span>
+                <strong>{data.hero.status}</strong>
+              </article>
+            </div>
+
+            <div className="role-organizer-actions">
+              <Link className="role-action-button role-action-primary" href="/turnirji/ancient-cup-ljubljana">
+                Open Control Panel
+              </Link>
+              <Link className="role-action-button role-action-secondary" href="/turnirji/ancient-cup-ljubljana">
+                View Live Bracket
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <RoleKpiGrid columns="five" items={data.kpis} />
+
+        <section className="role-organizer-grid">
+          <div className="role-organizer-main">
+            <RolePanel
+              title="Operational Matrix"
+              eyebrow="Live telemetry and match control center."
+              action={<span className="role-view-all">View all</span>}
+            >
+              <div className="role-table-wrap">
+                <table className="role-data-table">
+                  <thead>
+                    <tr>
+                      <th>Match ID</th>
+                      <th>Series</th>
+                      <th>Competitors</th>
+                      <th>Progress</th>
+                      <th>Integrity / Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.matrix.map((row) => (
+                      <tr key={row.matchId}>
+                        <td>{row.matchId}</td>
+                        <td>{row.series}</td>
+                        <td>
+                          <strong>{row.competitors}</strong>
+                        </td>
+                        <td>{row.progress}</td>
+                        <td>
+                          <StatusChip tone={row.status === "stable" ? "cyan" : row.status === "queued" ? "gold" : "muted"}>
+                            {row.status}
+                          </StatusChip>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </RolePanel>
+
+            <RolePanel title="Participating Squads">
+              <div className="role-squad-grid">
+                {data.squads.map((squad) => (
+                  <article key={squad.name}>
+                    <PlayerAvatar
+                      player={{
+                        avatarCode: squad.avatarCode,
+                        hero: "",
+                        id: squad.name,
+                        name: squad.name,
+                        role: ""
+                      }}
+                    />
+                    <strong>{squad.name}</strong>
+                    <StatusChip
+                      tone={
+                        squad.status === "approved"
+                          ? "cyan"
+                          : squad.status === "locked"
+                            ? "gold"
+                            : "red"
+                      }
+                    >
+                      {squad.status}
+                    </StatusChip>
+                    <button type="button">{squad.action}</button>
+                  </article>
+                ))}
+              </div>
+            </RolePanel>
+          </div>
+
+          <aside className="role-side-stack">
+            <RolePanel title="Quick Actions">
+              <div className="role-quick-actions role-organizer-actions-list">
+                {data.quickActions.map((action) => (
+                  <RoleActionButton action={action} key={action.label} />
+                ))}
+              </div>
+            </RolePanel>
+
+            <AlertsPanel alerts={data.alerts} />
+
+            <RolePanel title="Pipeline Status">
+              <div className="role-pipeline-list">
+                {data.pipeline.map((item) => (
+                  <article key={item.label}>
+                    <span>{item.label}</span>
+                    <strong className={`role-tone-text-${item.tone}`}>{item.value}</strong>
+                  </article>
+                ))}
+              </div>
+            </RolePanel>
+          </aside>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/player-dashboard-view.tsx
+++ b/frontend/src/components/dashboard/player-dashboard-view.tsx
@@ -1,0 +1,164 @@
+import { Gamepad2 } from "lucide-react";
+
+import {
+  DashboardTopbar,
+  FormChips,
+  PlayerAvatar,
+  RoleActionButton,
+  RolePanel,
+  StatusChip
+} from "@/components/dashboard/role-dashboard-primitives";
+import { playerDashboardData as data } from "@/lib/role-dashboard-data";
+import { classNames } from "@/lib/utils";
+
+export function PlayerDashboardView() {
+  return (
+    <div className="role-dashboard role-dashboard-player">
+      <DashboardTopbar
+        activeLabel="Active"
+        activeValue={data.topbar.activeTeam}
+        action={data.topbar.primaryAction}
+        rank={data.topbar.rank}
+      />
+
+      <div className="role-dashboard-content">
+        <section className="role-hero role-player-hero">
+          <div className="role-player-hero-copy">
+            <div className="role-hero-label-row">
+              <span className="role-hero-kicker">Pro Series</span>
+              <span>Live Event</span>
+            </div>
+            <h1>{data.hero.name}</h1>
+            <p>{data.hero.description}</p>
+            <div className="role-player-hero-actions">
+              <button className="role-action-button role-action-primary" type="button">
+                <Gamepad2 size={18} />
+                <span>Recap Replay</span>
+              </button>
+              <button className="role-action-button role-action-secondary" type="button">
+                Event Specs
+              </button>
+            </div>
+          </div>
+
+          <div className="role-hero-form role-player-form">
+            <span>Recent Form</span>
+            <FormChips values={data.hero.recentForm} />
+          </div>
+        </section>
+
+        <section className="role-player-grid">
+          <div className="role-player-main">
+            <div className="role-section-heading">
+              <h2>Personal Performance</h2>
+              <span>Last 20 Matches</span>
+            </div>
+
+            <div className="role-performance-grid">
+              {data.performance.map((metric) => (
+                <article
+                  className={classNames(
+                    "role-performance-card",
+                    `role-tone-${metric.tone}`,
+                    metric.featured && "is-featured"
+                  )}
+                  key={metric.label}
+                >
+                  <span>{metric.label}</span>
+                  <strong>{metric.value}</strong>
+                  {metric.detail ? <p>{metric.detail}</p> : null}
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <RolePanel title="Team Liquid Roster" className="role-player-roster-panel">
+            <div className="role-player-roster">
+              {data.roster.map((player) => (
+                <article key={player.id}>
+                  <PlayerAvatar player={player} />
+                  <div>
+                    <strong>{player.name}</strong>
+                    <span>{player.role}</span>
+                  </div>
+                  <StatusChip
+                    tone={
+                      player.status === "online"
+                        ? "cyan"
+                        : player.status === "in-game"
+                          ? "gold"
+                          : "muted"
+                    }
+                  >
+                    {player.status}
+                  </StatusChip>
+                </article>
+              ))}
+            </div>
+            <RoleActionButton
+              action={{ disabled: true, icon: Gamepad2, label: "Team Strat Room" }}
+              variant="secondary"
+            />
+          </RolePanel>
+        </section>
+
+        <RolePanel
+          title="Recent Match Log"
+          action={
+            <div className="role-table-actions">
+              <button type="button">All Roles</button>
+              <button type="button">Win Only</button>
+            </div>
+          }
+        >
+          <div className="role-table-wrap">
+            <table className="role-data-table role-match-log-table">
+              <thead>
+                <tr>
+                  <th>Hero</th>
+                  <th>Result</th>
+                  <th>Type</th>
+                  <th>K / D / A</th>
+                  <th>Duration</th>
+                  <th>GPM/XPM</th>
+                  <th>Analyzed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.matchLog.map((match) => (
+                  <tr key={`${match.hero}-${match.duration}`}>
+                    <td>
+                      <span className="role-hero-cell">
+                        <em>{match.hero.slice(0, 2).toUpperCase()}</em>
+                        <strong>{match.hero}</strong>
+                      </span>
+                    </td>
+                    <td>
+                      <StatusChip tone={match.result === "WIN" ? "green" : "red"}>
+                        {match.result}
+                      </StatusChip>
+                    </td>
+                    <td>{match.type}</td>
+                    <td>
+                      <strong>{match.kda}</strong>
+                    </td>
+                    <td>{match.duration}</td>
+                    <td>{match.gpmXpm}</td>
+                    <td>
+                      <StatusChip tone={match.analyzed === "Analyzing" ? "cyan" : "muted"}>
+                        {match.analyzed}
+                      </StatusChip>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <button className="role-load-more" type="button">
+            Load More Battle Records
+          </button>
+        </RolePanel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/public-dashboard-gate.tsx
+++ b/frontend/src/components/dashboard/public-dashboard-gate.tsx
@@ -1,0 +1,31 @@
+import { LockKeyhole, Trophy } from "lucide-react";
+import Link from "next/link";
+
+export function PublicDashboardGate() {
+  return (
+    <div className="role-dashboard role-dashboard-public">
+      <div className="role-public-shell">
+        <section className="role-public-card">
+          <div className="role-public-icon" aria-hidden="true">
+            <LockKeyhole size={28} />
+          </div>
+          <p className="role-hero-kicker">Restricted Dashboard</p>
+          <h1>Dashboard access requires login</h1>
+          <p>
+            Public visitors can view tournaments, schedules, brackets and results. Private team,
+            player and organizer dashboards are available after authentication.
+          </p>
+          <div className="role-public-actions">
+            <Link className="role-action-button role-action-primary" href="/turnirji">
+              <Trophy size={18} />
+              <span>View Public Tournaments</span>
+            </Link>
+            <button className="role-action-button role-action-secondary is-disabled" type="button" disabled>
+              Sign-in coming soon
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/role-dashboard-primitives.tsx
+++ b/frontend/src/components/dashboard/role-dashboard-primitives.tsx
@@ -1,0 +1,204 @@
+import { Bell, Shield, UserRound } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import type {
+  DashboardAction,
+  DashboardAlert,
+  DashboardKpi,
+  DashboardTone,
+  RosterPlayer
+} from "@/lib/role-dashboard-data";
+import { classNames } from "@/lib/utils";
+
+interface DashboardTopbarProps {
+  activeLabel: string;
+  activeValue: string;
+  action?: DashboardAction;
+  rank?: string;
+}
+
+export function DashboardTopbar({
+  activeLabel,
+  activeValue,
+  action,
+  rank
+}: DashboardTopbarProps) {
+  return (
+    <header className="role-dashboard-topbar">
+      <div className="role-topbar-left">
+        <div className="role-live-chip">
+          <span />
+          Live Uplink
+        </div>
+        <div className="role-active-context">
+          <span>{activeLabel}</span>
+          <strong>{activeValue}</strong>
+        </div>
+      </div>
+
+      <div className="role-topbar-actions">
+        {rank ? (
+          <div className="role-rank-chip">
+            <Shield size={15} />
+            <span>Rank</span>
+            <strong>{rank}</strong>
+          </div>
+        ) : null}
+        <button className="role-icon-button" type="button" aria-label="Notifications">
+          <Bell size={18} />
+        </button>
+        {action ? <RoleActionButton action={action} variant="primary" /> : null}
+        <div className="role-avatar" aria-label="User profile">
+          <UserRound size={18} />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export function RoleActionButton({
+  action,
+  variant = "panel"
+}: {
+  action: DashboardAction;
+  variant?: "primary" | "panel" | "secondary";
+}) {
+  const Icon = action.icon;
+  const className = classNames(
+    "role-action-button",
+    `role-action-${variant}`,
+    action.tone && `role-tone-${action.tone}`,
+    action.disabled && "is-disabled"
+  );
+  const content = (
+    <>
+      <Icon size={18} />
+      <span>{action.label}</span>
+    </>
+  );
+
+  if (action.href && !action.disabled) {
+    return (
+      <Link className={className} href={action.href}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button className={className} type="button" disabled={action.disabled}>
+      {content}
+    </button>
+  );
+}
+
+export function RoleKpiGrid({
+  columns = "four",
+  items
+}: {
+  columns?: "three" | "four" | "five";
+  items: DashboardKpi[];
+}) {
+  return (
+    <section className={classNames("role-kpi-grid", `role-kpi-${columns}`)} aria-label="Dashboard KPIs">
+      {items.map((item) => (
+        <RoleKpiCard item={item} key={item.label} />
+      ))}
+    </section>
+  );
+}
+
+export function RoleKpiCard({ item }: { item: DashboardKpi }) {
+  const Icon = item.icon;
+
+  return (
+    <article className={classNames("role-kpi-card", `role-tone-${item.tone}`)}>
+      <div className="role-kpi-heading">
+        <span>{item.label}</span>
+        <Icon size={20} />
+      </div>
+      <div className="role-kpi-value-row">
+        <strong>{item.value}</strong>
+        {typeof item.progress === "number" ? (
+          <div className="role-progress-track" aria-hidden="true">
+            <span style={{ width: `${item.progress}%` }} />
+          </div>
+        ) : null}
+      </div>
+      {item.detail ? <p>{item.detail}</p> : null}
+    </article>
+  );
+}
+
+export function FormChips({ values }: { values: Array<"W" | "L"> }) {
+  return (
+    <div className="role-form-chips" aria-label="Recent form">
+      {values.map((value, index) => (
+        <span className={value === "W" ? "is-win" : "is-loss"} key={`${value}-${index}`}>
+          {value}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function StatusChip({
+  children,
+  tone = "muted"
+}: {
+  children: ReactNode;
+  tone?: DashboardTone;
+}) {
+  return <span className={classNames("role-status-chip", `role-tone-${tone}`)}>{children}</span>;
+}
+
+export function RolePanel({
+  action,
+  children,
+  className,
+  eyebrow,
+  title
+}: {
+  action?: ReactNode;
+  children: ReactNode;
+  className?: string;
+  eyebrow?: string;
+  title: string;
+}) {
+  return (
+    <section className={classNames("role-panel", className)}>
+      <div className="role-panel-header">
+        <div>
+          {eyebrow ? <p>{eyebrow}</p> : null}
+          <h2>{title}</h2>
+        </div>
+        {action ? <div>{action}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function AlertsPanel({ alerts }: { alerts: DashboardAlert[] }) {
+  return (
+    <RolePanel title="Tactical Alerts" className="role-alert-panel">
+      <div className="role-alert-list">
+        {alerts.map((alert) => (
+          <article className={classNames("role-alert", `role-tone-${alert.tone}`)} key={alert.title}>
+            <strong>{alert.title}</strong>
+            <p>{alert.detail}</p>
+          </article>
+        ))}
+      </div>
+    </RolePanel>
+  );
+}
+
+export function PlayerAvatar({ player }: { player: RosterPlayer }) {
+  return (
+    <span className="role-player-avatar" aria-hidden="true">
+      {player.avatarCode}
+    </span>
+  );
+}

--- a/frontend/src/components/dashboard/role-dashboard.tsx
+++ b/frontend/src/components/dashboard/role-dashboard.tsx
@@ -1,0 +1,21 @@
+import { CaptainDashboardView } from "@/components/dashboard/captain-dashboard-view";
+import { OrganizerDashboardView } from "@/components/dashboard/organizer-dashboard-view";
+import { PlayerDashboardView } from "@/components/dashboard/player-dashboard-view";
+import { PublicDashboardGate } from "@/components/dashboard/public-dashboard-gate";
+import type { DashboardRole } from "@/lib/role-dashboard-data";
+
+export function RoleDashboard({ role }: { role: DashboardRole }) {
+  if (role === "player") {
+    return <PlayerDashboardView />;
+  }
+
+  if (role === "organizer") {
+    return <OrganizerDashboardView />;
+  }
+
+  if (role === "public") {
+    return <PublicDashboardGate />;
+  }
+
+  return <CaptainDashboardView />;
+}

--- a/frontend/src/lib/role-dashboard-data.ts
+++ b/frontend/src/lib/role-dashboard-data.ts
@@ -1,0 +1,444 @@
+import {
+  BarChart3,
+  Brackets,
+  CalendarDays,
+  DatabaseZap,
+  FileInput,
+  Gamepad2,
+  ListChecks,
+  RadioTower,
+  Sparkles,
+  Swords,
+  Trophy,
+  UserPlus,
+  UsersRound,
+  Zap
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export type DashboardRole = "captain" | "player" | "organizer" | "public";
+export type DashboardTone = "red" | "gold" | "cyan" | "green" | "muted";
+
+export interface DashboardKpi {
+  label: string;
+  value: string;
+  detail?: string;
+  tone: DashboardTone;
+  icon: LucideIcon;
+  progress?: number;
+}
+
+export interface DashboardAction {
+  label: string;
+  href?: string;
+  disabled?: boolean;
+  icon: LucideIcon;
+  tone?: DashboardTone;
+}
+
+export interface DashboardAlert {
+  title: string;
+  detail: string;
+  tone: DashboardTone;
+}
+
+export interface RosterPlayer {
+  id: string;
+  name: string;
+  role: string;
+  hero: string;
+  status?: "online" | "in-game" | "offline";
+  avatarCode: string;
+}
+
+export interface CaptainMatch {
+  tournament: string;
+  detail: string;
+  opponent: string;
+  opponentCode: string;
+  time: string;
+  status: "ready" | "queued" | "locked";
+}
+
+export interface CaptainDashboardData {
+  topbar: {
+    activeTeam: string;
+    rank: string;
+    primaryAction: DashboardAction;
+  };
+  kpis: DashboardKpi[];
+  hero: {
+    team: string;
+    status: string;
+    opponent: string;
+    opponentCode: string;
+    scheduledStart: string;
+    recentForm: Array<"W" | "L">;
+  };
+  upcomingMatches: CaptainMatch[];
+  quickActions: DashboardAction[];
+  roster: RosterPlayer[];
+  alerts: DashboardAlert[];
+  performance: DashboardKpi[];
+}
+
+export interface PlayerMetric {
+  label: string;
+  value: string;
+  detail?: string;
+  tone: DashboardTone;
+  featured?: boolean;
+}
+
+export interface PlayerMatchLog {
+  hero: string;
+  result: "WIN" | "LOSS";
+  type: string;
+  kda: string;
+  duration: string;
+  gpmXpm: string;
+  analyzed: "Analyzing" | "Completed";
+}
+
+export interface PlayerDashboardData {
+  topbar: {
+    activeTeam: string;
+    rank: string;
+    primaryAction: DashboardAction;
+  };
+  hero: {
+    name: string;
+    role: string;
+    label: string;
+    description: string;
+    recentForm: Array<"W" | "L">;
+  };
+  performance: PlayerMetric[];
+  roster: RosterPlayer[];
+  matchLog: PlayerMatchLog[];
+}
+
+export interface OrganizerMatrixRow {
+  matchId: string;
+  series: string;
+  competitors: string;
+  progress: string;
+  status: "stable" | "queued" | "locked";
+}
+
+export interface OrganizerSquad {
+  name: string;
+  status: "approved" | "locked" | "pending";
+  action: string;
+  avatarCode: string;
+}
+
+export interface PipelineItem {
+  label: string;
+  value: string;
+  tone: DashboardTone;
+}
+
+export interface OrganizerDashboardData {
+  topbar: {
+    activeTournament: string;
+    primaryAction: DashboardAction;
+  };
+  hero: {
+    title: string;
+    stage: string;
+    description: string;
+    registeredTeams: string;
+    integrity: string;
+    status: string;
+  };
+  kpis: DashboardKpi[];
+  matrix: OrganizerMatrixRow[];
+  quickActions: DashboardAction[];
+  squads: OrganizerSquad[];
+  alerts: DashboardAlert[];
+  pipeline: PipelineItem[];
+}
+
+export const captainDashboardData: CaptainDashboardData = {
+  topbar: {
+    activeTeam: "Team Liquid",
+    rank: "Immortal",
+    primaryAction: {
+      href: "/turnirji",
+      icon: Trophy,
+      label: "Join Tournament"
+    }
+  },
+  kpis: [
+    {
+      icon: Trophy,
+      label: "Active Tournaments",
+      progress: 32,
+      tone: "red",
+      value: "02"
+    },
+    {
+      icon: CalendarDays,
+      label: "Upcoming Matches",
+      progress: 52,
+      tone: "gold",
+      value: "03"
+    },
+    {
+      icon: BarChart3,
+      label: "Team Win Rate",
+      progress: 64,
+      tone: "cyan",
+      value: "64%"
+    },
+    {
+      icon: DatabaseZap,
+      label: "Match Data Ready",
+      progress: 78,
+      tone: "red",
+      value: "12"
+    }
+  ],
+  hero: {
+    opponent: "Gaimin Gladiators",
+    opponentCode: "GG",
+    recentForm: ["L", "W", "W", "L", "W"],
+    scheduledStart: "14:30 UTC",
+    status: "Active",
+    team: "Team Liquid"
+  },
+  upcomingMatches: [
+    {
+      detail: "Group Stage B",
+      opponent: "Team OG",
+      opponentCode: "OG",
+      status: "ready",
+      time: "18:00 UTC",
+      tournament: "DreamLeague S22"
+    },
+    {
+      detail: "Main Event",
+      opponent: "Team Spirit",
+      opponentCode: "TS",
+      status: "queued",
+      time: "Tomorrow",
+      tournament: "Elite League"
+    },
+    {
+      detail: "Qualifier",
+      opponent: "Azure Ray",
+      opponentCode: "AZ",
+      status: "locked",
+      time: "Feb 24",
+      tournament: "Dota OPS Closed"
+    }
+  ],
+  quickActions: [
+    { href: "/turnirji", icon: UserPlus, label: "Join New Tournament", tone: "red" },
+    { href: "/ekipe", icon: UsersRound, label: "View Team Roster", tone: "gold" },
+    { disabled: true, icon: FileInput, label: "Submit Match Result", tone: "cyan" },
+    { disabled: true, icon: DatabaseZap, label: "Import Match ID", tone: "red" }
+  ],
+  roster: [
+    { avatarCode: "MP", hero: "Puck", id: "midpulse", name: "MidPulse", role: "Mid" },
+    { avatarCode: "SM", hero: "Juggernaut", id: "safemode", name: "SafeMode", role: "Carry" },
+    { avatarCode: "OG", hero: "Mars", id: "offgrid", name: "OffGrid", role: "Offlane" },
+    { avatarCode: "VI", hero: "Crystal Maiden", id: "vision", name: "Vision", role: "Support" },
+    { avatarCode: "SC", hero: "Rubick", id: "shotcall", name: "Shotcall", role: "Captain" }
+  ],
+  alerts: [
+    {
+      detail: "DreamLeague roster locks in 04h 12m. One player signature pending.",
+      title: "Roster Lock Imminent",
+      tone: "red"
+    },
+    {
+      detail: "Gaimin Gladiators recently played 3 matches with Terrorblade.",
+      title: "Scouting Update",
+      tone: "gold"
+    }
+  ],
+  performance: [
+    {
+      detail: "+5%",
+      icon: BarChart3,
+      label: "Win Rate Last 20",
+      tone: "cyan",
+      value: "72%"
+    },
+    {
+      detail: "Stable",
+      icon: Swords,
+      label: "Avg Team KDA",
+      tone: "gold",
+      value: "4.2"
+    },
+    {
+      detail: "core pool",
+      icon: Sparkles,
+      label: "Most Played Hero",
+      tone: "red",
+      value: "Rubick"
+    }
+  ]
+};
+
+export const playerDashboardData: PlayerDashboardData = {
+  topbar: {
+    activeTeam: "Team Liquid",
+    rank: "Immortal",
+    primaryAction: {
+      disabled: true,
+      icon: Gamepad2,
+      label: "View Match Briefing"
+    }
+  },
+  hero: {
+    description:
+      "Dominating the central lane with pinpoint accuracy and elite tactical awareness. Welcome to your command center, Commander.",
+    label: "Pro Series / Live Event",
+    name: "MidPulse Elite",
+    recentForm: ["W", "W", "L", "W", "W"],
+    role: "Mid / Position 2"
+  },
+  performance: [
+    { detail: "+0.42 vs Avg", featured: true, label: "KDA Ratio", tone: "cyan", value: "4.82" },
+    { featured: true, label: "Win Rate", tone: "red", value: "68.5%" },
+    { detail: "Elite Veteran", featured: true, label: "Matches", tone: "muted", value: "1,240" },
+    { detail: "92% to Immortal", featured: true, label: "Rank Tier", tone: "gold", value: "Divine IV" },
+    { detail: "+12% last 10", label: "AVG GPM", tone: "green", value: "642" },
+    { detail: "Stable trend", label: "AVG XPM", tone: "muted", value: "718" },
+    { detail: "-3% vs avg", label: "Last Hits @10", tone: "red", value: "54.2" },
+    { detail: "+5% high impact", label: "Kill Participation", tone: "green", value: "72.4%" }
+  ],
+  roster: [
+    { avatarCode: "MC", hero: "Lifestealer", id: "micke", name: "miCKe", role: "Carry / Pos 1", status: "online" },
+    { avatarCode: "NI", hero: "Puck", id: "nisha", name: "Nisha", role: "Mid / Pos 2", status: "online" },
+    { avatarCode: "33", hero: "Beastmaster", id: "33", name: "33", role: "Offlane / Pos 3", status: "in-game" },
+    { avatarCode: "BX", hero: "Tusk", id: "boxi", name: "Boxi", role: "Support / Pos 4", status: "online" },
+    { avatarCode: "IN", hero: "Oracle", id: "insania", name: "Insania", role: "Hard Support / Pos 5", status: "offline" }
+  ],
+  matchLog: [
+    {
+      analyzed: "Analyzing",
+      duration: "34:12",
+      gpmXpm: "742 / 812",
+      hero: "Shadow Fiend",
+      kda: "14 / 2 / 8",
+      result: "WIN",
+      type: "Ranked Solo"
+    },
+    {
+      analyzed: "Completed",
+      duration: "41:05",
+      gpmXpm: "512 / 640",
+      hero: "Puck",
+      kda: "9 / 10 / 12",
+      result: "LOSS",
+      type: "Matchmaking"
+    },
+    {
+      analyzed: "Completed",
+      duration: "28:55",
+      gpmXpm: "890 / 920",
+      hero: "Invoker",
+      kda: "22 / 1 / 15",
+      result: "WIN",
+      type: "Pro Scrim"
+    }
+  ]
+};
+
+export const organizerDashboardData: OrganizerDashboardData = {
+  topbar: {
+    activeTournament: "TI Global Finals",
+    primaryAction: {
+      href: "/organizator",
+      icon: Trophy,
+      label: "New Tournament"
+    }
+  },
+  hero: {
+    description:
+      "Group Stage | Round 4. Monitoring real-time telemetry from all 16 active instances. Integrity status remains stable across all clusters.",
+    integrity: "Stable",
+    registeredTeams: "16/16",
+    stage: "Pro Series / Live Feed: Arena A-01",
+    status: "Live Operations",
+    title: "TI Global Finals"
+  },
+  kpis: [
+    { icon: Trophy, label: "Active Tournaments", progress: 34, tone: "red", value: "02" },
+    { icon: UsersRound, label: "Registered Teams", progress: 100, tone: "gold", value: "16/16" },
+    { icon: ListChecks, label: "Pending Approvals", progress: 4, tone: "red", value: "00" },
+    { icon: Zap, label: "Live Matches", progress: 70, tone: "cyan", value: "03" },
+    { icon: DatabaseZap, label: "Match Data Ready", progress: 48, tone: "red", value: "12" }
+  ],
+  matrix: [
+    {
+      competitors: "Spirit vs Gaimin",
+      matchId: "#7710242",
+      progress: "34:21",
+      series: "Grand Finals BO5",
+      status: "stable"
+    },
+    {
+      competitors: "Liquid vs Azure Ray",
+      matchId: "#7710250",
+      progress: "Upcoming",
+      series: "Lower Bracket BO3",
+      status: "queued"
+    },
+    {
+      competitors: "BetBoom vs Xtreme",
+      matchId: "#7710258",
+      progress: "Upcoming",
+      series: "Lower Bracket BO3",
+      status: "locked"
+    }
+  ],
+  quickActions: [
+    { disabled: true, icon: Brackets, label: "Generate Bracket", tone: "gold" },
+    { disabled: true, icon: RadioTower, label: "Publish Schedule", tone: "cyan" },
+    { disabled: true, icon: FileInput, label: "Enter Results", tone: "red" },
+    { disabled: true, icon: DatabaseZap, label: "Import Match Data", tone: "cyan" }
+  ],
+  squads: [
+    { action: "View Roster", avatarCode: "TS", name: "Team Spirit", status: "approved" },
+    { action: "View Roster", avatarCode: "TL", name: "Team Liquid", status: "locked" },
+    { action: "Review Data", avatarCode: "GG", name: "Gaimin Gladiators", status: "pending" }
+  ],
+  alerts: [
+    {
+      detail: "DreamLeague roster locks in 04h 12m. One player signature pending.",
+      title: "Roster Lock Imminent",
+      tone: "red"
+    },
+    {
+      detail: "Cluster SG-04 reporting 120ms+ latency. Redirecting local traffic to HK-01.",
+      title: "Server Latency Spike in SEA",
+      tone: "gold"
+    },
+    {
+      detail: "Team Xtreme submitted a technical review request for Game 2.",
+      title: "Pending Protest: Match M-2024-001",
+      tone: "red"
+    }
+  ],
+  pipeline: [
+    { label: "OpenDota Sync", tone: "cyan", value: "99.9% Active" },
+    { label: "Telemetry Flow", tone: "cyan", value: "Healthy" },
+    { label: "API Relay (EU-W)", tone: "red", value: "Stable" }
+  ]
+};
+
+export function normalizeDashboardRole(value?: string | string[]): DashboardRole {
+  const role = Array.isArray(value) ? value[0] : value;
+
+  if (role === "player" || role === "captain" || role === "organizer" || role === "public") {
+    return role;
+  }
+
+  return "captain";
+}


### PR DESCRIPTION
## Povzetek

Implementirani so role-based dashboard pogledi za:
- navadnega igralca
- kapetana ekipe
- organizatorja
- public/restricted fallback

## Dodano

- `/dashboard?role=player`
- `/dashboard?role=captain`
- `/dashboard?role=organizer`
- `/dashboard?role=public`

## Tehnično

- dodane nove dashboard komponente
- dodani mock podatki za role dashboarde
- backend ni bil spremenjen
- pripravljeno za kasnejšo povezavo z auth/role podatki iz backend API-ja

## Preverjeno

- lint uspešen
- typecheck uspešen