### PR TITLE
fix(db): allow V12 migration on Supabase

### DIFF
--- a/backend/src/main/resources/db/migration/V12__create_profiles_for_auth_users.sql
+++ b/backend/src/main/resources/db/migration/V12__create_profiles_for_auth_users.sql
@@ -198,5 +198,3 @@ grant execute on function private.ensure_profile_for_auth_user(uuid, text, jsonb
 
 comment on constraint profiles_role_no_global_captain on public.profiles is
   'Team captain is a team-specific capability from teams.captain_profile_id/team membership, not a global account role.';
-comment on trigger dotaops_create_profile_on_auth_user on auth.users is
-  'Creates a minimal DotaOps profile for each Supabase Auth user without trusting privileged user metadata.';


### PR DESCRIPTION
## Summary
- remove the `COMMENT ON TRIGGER ... ON auth.users` statement from V12
- keep the auth.users profile creation trigger/function behavior unchanged
- fix backend startup during `docker compose up --build` on Supabase, where the app DB user can create the trigger but is not owner of `auth.users`

## Verification
- `./mvnw.cmd test -Dspring.profiles.active=test`
- `./mvnw.cmd -B -Dtest=*IntegrationTest test -Dspring.profiles.active=integration` locally completed with integration tests skipped because `SUPABASE_DB_URL` is not configured locally
- `docker compose up --build -d`
- backend container started successfully and Flyway migrated to V12
- `GET /actuator/health` returned UP
- frontend returned HTTP 200 on `http://localhost:3000`
- `GET /api/tournaments` returned HTTP 200
- `git diff --check`