### PR TITLE
BE/DB-12 Implementiraj prijave ekip, odobritve in check-in

### DIFF
--- a/backend/src/main/java/si/um/feri/dotaops/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/steam/logout").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                 "/api/teams/*/invitations",
+                                "/api/teams/*/tournament-registrations",
                                 "/api/teams/*/invitations/**").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/match-imports").authenticated()
                         .requestMatchers(HttpMethod.GET,

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistration.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistration.java
@@ -1,0 +1,28 @@
+package si.um.feri.dotaops.backend.tournament.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record TournamentRegistration(
+        UUID id,
+        UUID tournamentId,
+        String tournamentSlug,
+        String tournamentTitle,
+        UUID teamId,
+        String teamName,
+        String teamTag,
+        String teamSlug,
+        UUID captainProfileId,
+        String captainNickname,
+        TournamentRegistrationStatus status,
+        String message,
+        UUID reviewedBy,
+        String reviewedByNickname,
+        OffsetDateTime reviewedAt,
+        Integer seedNumber,
+        OffsetDateTime checkedInAt,
+        String contactEmail,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistrationMember.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistrationMember.java
@@ -1,0 +1,21 @@
+package si.um.feri.dotaops.backend.tournament.domain;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import si.um.feri.dotaops.backend.team.domain.TeamMemberRole;
+
+public record TournamentRegistrationMember(
+        UUID id,
+        UUID registrationId,
+        UUID profileId,
+        String nickname,
+        String displayName,
+        String avatarUrl,
+        UUID teamMemberId,
+        TeamMemberRole memberRole,
+        boolean starter,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistrationStatus.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/domain/TournamentRegistrationStatus.java
@@ -1,0 +1,40 @@
+package si.um.feri.dotaops.backend.tournament.domain;
+
+import java.util.Locale;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum TournamentRegistrationStatus {
+    PENDING("pending"),
+    APPROVED("approved"),
+    REJECTED("rejected"),
+    WAITLISTED("waitlisted");
+
+    private final String databaseValue;
+
+    TournamentRegistrationStatus(String databaseValue) {
+        this.databaseValue = databaseValue;
+    }
+
+    @JsonValue
+    public String databaseValue() {
+        return databaseValue;
+    }
+
+    @JsonCreator
+    public static TournamentRegistrationStatus fromDatabaseValue(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Tournament registration status is required.");
+        }
+
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (TournamentRegistrationStatus status : values()) {
+            if (status.databaseValue.equals(normalized)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown tournament registration status: " + value);
+    }
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/CreateTournamentRegistrationRequest.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/CreateTournamentRegistrationRequest.java
@@ -1,0 +1,20 @@
+package si.um.feri.dotaops.backend.tournament.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateTournamentRegistrationRequest(
+        @NotNull
+        UUID teamId,
+
+        @Size(max = 1000)
+        String message,
+
+        @Email
+        @Size(max = 254)
+        String contactEmail
+) {
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/ReviewTournamentRegistrationRequest.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/ReviewTournamentRegistrationRequest.java
@@ -1,0 +1,9 @@
+package si.um.feri.dotaops.backend.tournament.dto;
+
+import jakarta.validation.constraints.Min;
+
+public record ReviewTournamentRegistrationRequest(
+        @Min(1)
+        Integer seedNumber
+) {
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/TournamentRegistrationMemberResponse.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/TournamentRegistrationMemberResponse.java
@@ -1,0 +1,34 @@
+package si.um.feri.dotaops.backend.tournament.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationMember;
+
+public record TournamentRegistrationMemberResponse(
+        UUID id,
+        UUID profileId,
+        String nickname,
+        String displayName,
+        String avatarUrl,
+        UUID teamMemberId,
+        String role,
+        boolean starter,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+
+    public static TournamentRegistrationMemberResponse from(TournamentRegistrationMember member) {
+        return new TournamentRegistrationMemberResponse(
+                member.id(),
+                member.profileId(),
+                member.nickname(),
+                member.displayName(),
+                member.avatarUrl(),
+                member.teamMemberId(),
+                member.memberRole().databaseValue(),
+                member.starter(),
+                member.createdAt(),
+                member.updatedAt());
+    }
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/TournamentRegistrationResponse.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/dto/TournamentRegistrationResponse.java
@@ -1,0 +1,63 @@
+package si.um.feri.dotaops.backend.tournament.dto;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistration;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationMember;
+
+public record TournamentRegistrationResponse(
+        UUID id,
+        UUID tournamentId,
+        String tournamentSlug,
+        String tournamentTitle,
+        UUID teamId,
+        String teamName,
+        String teamTag,
+        String teamSlug,
+        UUID captainProfileId,
+        String captainNickname,
+        String status,
+        String message,
+        UUID reviewedBy,
+        String reviewedByNickname,
+        OffsetDateTime reviewedAt,
+        Integer seedNumber,
+        OffsetDateTime checkedInAt,
+        String contactEmail,
+        List<TournamentRegistrationMemberResponse> members,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
+) {
+
+    public static TournamentRegistrationResponse from(
+            TournamentRegistration registration,
+            List<TournamentRegistrationMember> members
+    ) {
+        return new TournamentRegistrationResponse(
+                registration.id(),
+                registration.tournamentId(),
+                registration.tournamentSlug(),
+                registration.tournamentTitle(),
+                registration.teamId(),
+                registration.teamName(),
+                registration.teamTag(),
+                registration.teamSlug(),
+                registration.captainProfileId(),
+                registration.captainNickname(),
+                registration.status().databaseValue(),
+                registration.message(),
+                registration.reviewedBy(),
+                registration.reviewedByNickname(),
+                registration.reviewedAt(),
+                registration.seedNumber(),
+                registration.checkedInAt(),
+                registration.contactEmail(),
+                members.stream()
+                        .map(TournamentRegistrationMemberResponse::from)
+                        .toList(),
+                registration.createdAt(),
+                registration.updatedAt());
+    }
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/repository/CreateTournamentRegistrationCommand.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/repository/CreateTournamentRegistrationCommand.java
@@ -1,0 +1,12 @@
+package si.um.feri.dotaops.backend.tournament.repository;
+
+import java.util.UUID;
+
+public record CreateTournamentRegistrationCommand(
+        UUID tournamentId,
+        UUID teamId,
+        UUID captainProfileId,
+        String message,
+        String contactEmail
+) {
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/repository/TournamentRegistrationRepository.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/repository/TournamentRegistrationRepository.java
@@ -1,0 +1,370 @@
+package si.um.feri.dotaops.backend.tournament.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import si.um.feri.dotaops.backend.team.domain.TeamMemberRole;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistration;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationMember;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationStatus;
+
+@Repository
+public class TournamentRegistrationRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public TournamentRegistrationRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<TournamentRegistration> findByTournamentId(UUID tournamentId, TournamentRegistrationStatus status) {
+        String statusValue = status == null ? null : status.databaseValue();
+
+        return jdbcTemplate.query(
+                selectRegistrationSql() + """
+                where tr.tournament_id = ?
+                  and (
+                    cast(? as text) is null
+                    or tr.status = cast(? as public.dotaops_registration_status)
+                  )
+                order by tr.seed_number nulls last, tr.created_at asc, tr.id asc
+                """,
+                this::mapRegistration,
+                tournamentId,
+                statusValue,
+                statusValue);
+    }
+
+    public List<TournamentRegistration> findByTeamId(UUID teamId) {
+        return jdbcTemplate.query(
+                selectRegistrationSql() + """
+                where tr.team_id = ?
+                order by tr.created_at desc, tr.id desc
+                """,
+                this::mapRegistration,
+                teamId);
+    }
+
+    public Optional<TournamentRegistration> findById(UUID registrationId) {
+        return jdbcTemplate.query(
+                        selectRegistrationSql() + """
+                        where tr.id = ?
+                        limit 1
+                        """,
+                        this::mapRegistration,
+                        registrationId)
+                .stream()
+                .findFirst();
+    }
+
+    public Optional<TournamentRegistration> findByIdAndTournamentId(UUID registrationId, UUID tournamentId) {
+        return jdbcTemplate.query(
+                        selectRegistrationSql() + """
+                        where tr.id = ?
+                          and tr.tournament_id = ?
+                        limit 1
+                        """,
+                        this::mapRegistration,
+                        registrationId,
+                        tournamentId)
+                .stream()
+                .findFirst();
+    }
+
+    public int countActiveRosterMembers(UUID teamId) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                select count(*)
+                from public.team_members
+                where team_id = ?
+                  and is_active = true
+                """,
+                Integer.class,
+                teamId);
+
+        return count == null ? 0 : count;
+    }
+
+    public long countApprovedRegistrations(UUID tournamentId, UUID excludingRegistrationId) {
+        Long count = jdbcTemplate.queryForObject(
+                """
+                select count(*)
+                from public.tournament_registrations
+                where tournament_id = ?
+                  and status = 'approved'
+                  and (cast(? as uuid) is null or id <> ?)
+                """,
+                Long.class,
+                tournamentId,
+                excludingRegistrationId,
+                excludingRegistrationId);
+
+        return count == null ? 0 : count;
+    }
+
+    public TournamentRegistration create(CreateTournamentRegistrationCommand command, int rosterSnapshotSize) {
+        TournamentRegistration registration = jdbcTemplate.queryForObject(
+                """
+                insert into public.tournament_registrations (
+                  tournament_id,
+                  team_id,
+                  captain_profile_id,
+                  message,
+                  contact_email
+                )
+                values (?, ?, ?, ?, ?)
+                """ + returningRegistrationSql(),
+                this::mapRegistration,
+                command.tournamentId(),
+                command.teamId(),
+                command.captainProfileId(),
+                command.message(),
+                command.contactEmail());
+
+        snapshotActiveRoster(registration.id(), command.teamId(), command.captainProfileId(), rosterSnapshotSize);
+
+        return findById(registration.id()).orElse(registration);
+    }
+
+    public Optional<TournamentRegistration> updateStatus(
+            UUID registrationId,
+            UUID tournamentId,
+            TournamentRegistrationStatus status,
+            UUID reviewedBy,
+            Integer seedNumber
+    ) {
+        return jdbcTemplate.query(
+                        """
+                        update public.tournament_registrations
+                        set
+                          status = cast(? as public.dotaops_registration_status),
+                          reviewed_by = ?,
+                          reviewed_at = now(),
+                          seed_number = case
+                            when cast(? as public.dotaops_registration_status) = 'approved' then ?
+                            else null
+                          end,
+                          updated_at = now()
+                        where id = ?
+                          and tournament_id = ?
+                        """ + returningRegistrationSql(),
+                        this::mapRegistration,
+                        status.databaseValue(),
+                        reviewedBy,
+                        status.databaseValue(),
+                        seedNumber,
+                        registrationId,
+                        tournamentId)
+                .stream()
+                .findFirst();
+    }
+
+    public Optional<TournamentRegistration> checkIn(UUID registrationId, UUID tournamentId) {
+        return jdbcTemplate.query(
+                        """
+                        update public.tournament_registrations
+                        set
+                          checked_in_at = coalesce(checked_in_at, now()),
+                          updated_at = now()
+                        where id = ?
+                          and tournament_id = ?
+                        """ + returningRegistrationSql(),
+                        this::mapRegistration,
+                        registrationId,
+                        tournamentId)
+                .stream()
+                .findFirst();
+    }
+
+    public List<TournamentRegistrationMember> findMembers(UUID registrationId) {
+        return jdbcTemplate.query(
+                """
+                select
+                  trm.id,
+                  trm.registration_id,
+                  trm.profile_id,
+                  p.nickname,
+                  p.display_name,
+                  p.avatar_url,
+                  trm.team_member_id,
+                  trm.member_role::text as member_role,
+                  trm.is_starter,
+                  trm.created_at,
+                  trm.updated_at
+                from public.tournament_registration_members trm
+                join public.profiles p on p.id = trm.profile_id
+                where trm.registration_id = ?
+                order by trm.is_starter desc, trm.created_at asc, trm.id asc
+                """,
+                this::mapRegistrationMember,
+                registrationId);
+    }
+
+    private void snapshotActiveRoster(
+            UUID registrationId,
+            UUID teamId,
+            UUID captainProfileId,
+            int rosterSnapshotSize
+    ) {
+        jdbcTemplate.update(
+                """
+                insert into public.tournament_registration_members (
+                  registration_id,
+                  profile_id,
+                  team_member_id,
+                  member_role,
+                  is_starter
+                )
+                select
+                  ?,
+                  tm.profile_id,
+                  tm.id,
+                  tm.member_role,
+                  true
+                from public.team_members tm
+                where tm.team_id = ?
+                  and tm.is_active = true
+                order by
+                  case when tm.profile_id = ? then 0 else 1 end,
+                  tm.joined_at asc,
+                  tm.id asc
+                limit ?
+                on conflict (registration_id, profile_id) do nothing
+                """,
+                registrationId,
+                teamId,
+                captainProfileId,
+                rosterSnapshotSize);
+    }
+
+    private String selectRegistrationSql() {
+        return """
+                select
+                  tr.id,
+                  tr.tournament_id,
+                  t.slug as tournament_slug,
+                  t.title as tournament_title,
+                  tr.team_id,
+                  tm.name as team_name,
+                  tm.tag as team_tag,
+                  tm.slug as team_slug,
+                  tr.captain_profile_id,
+                  cp.nickname as captain_nickname,
+                  tr.status::text as status,
+                  tr.message,
+                  tr.reviewed_by,
+                  rp.nickname as reviewed_by_nickname,
+                  tr.reviewed_at,
+                  tr.seed_number,
+                  tr.checked_in_at,
+                  tr.contact_email,
+                  tr.created_at,
+                  tr.updated_at
+                from public.tournament_registrations tr
+                join public.tournaments t on t.id = tr.tournament_id
+                join public.teams tm on tm.id = tr.team_id
+                left join public.profiles cp on cp.id = tr.captain_profile_id
+                left join public.profiles rp on rp.id = tr.reviewed_by
+                """;
+    }
+
+    private String returningRegistrationSql() {
+        return """
+                returning
+                  id,
+                  tournament_id,
+                  (
+                    select t.slug
+                    from public.tournaments t
+                    where t.id = tournament_id
+                  ) as tournament_slug,
+                  (
+                    select t.title
+                    from public.tournaments t
+                    where t.id = tournament_id
+                  ) as tournament_title,
+                  team_id,
+                  (
+                    select tm.name
+                    from public.teams tm
+                    where tm.id = team_id
+                  ) as team_name,
+                  (
+                    select tm.tag
+                    from public.teams tm
+                    where tm.id = team_id
+                  ) as team_tag,
+                  (
+                    select tm.slug
+                    from public.teams tm
+                    where tm.id = team_id
+                  ) as team_slug,
+                  captain_profile_id,
+                  (
+                    select cp.nickname
+                    from public.profiles cp
+                    where cp.id = captain_profile_id
+                  ) as captain_nickname,
+                  status::text as status,
+                  message,
+                  reviewed_by,
+                  (
+                    select rp.nickname
+                    from public.profiles rp
+                    where rp.id = reviewed_by
+                  ) as reviewed_by_nickname,
+                  reviewed_at,
+                  seed_number,
+                  checked_in_at,
+                  contact_email,
+                  created_at,
+                  updated_at
+                """;
+    }
+
+    private TournamentRegistration mapRegistration(ResultSet resultSet, int rowNumber) throws SQLException {
+        return new TournamentRegistration(
+                resultSet.getObject("id", UUID.class),
+                resultSet.getObject("tournament_id", UUID.class),
+                resultSet.getString("tournament_slug"),
+                resultSet.getString("tournament_title"),
+                resultSet.getObject("team_id", UUID.class),
+                resultSet.getString("team_name"),
+                resultSet.getString("team_tag"),
+                resultSet.getString("team_slug"),
+                resultSet.getObject("captain_profile_id", UUID.class),
+                resultSet.getString("captain_nickname"),
+                TournamentRegistrationStatus.fromDatabaseValue(resultSet.getString("status")),
+                resultSet.getString("message"),
+                resultSet.getObject("reviewed_by", UUID.class),
+                resultSet.getString("reviewed_by_nickname"),
+                resultSet.getObject("reviewed_at", OffsetDateTime.class),
+                resultSet.getObject("seed_number", Integer.class),
+                resultSet.getObject("checked_in_at", OffsetDateTime.class),
+                resultSet.getString("contact_email"),
+                resultSet.getObject("created_at", OffsetDateTime.class),
+                resultSet.getObject("updated_at", OffsetDateTime.class));
+    }
+
+    private TournamentRegistrationMember mapRegistrationMember(ResultSet resultSet, int rowNumber) throws SQLException {
+        return new TournamentRegistrationMember(
+                resultSet.getObject("id", UUID.class),
+                resultSet.getObject("registration_id", UUID.class),
+                resultSet.getObject("profile_id", UUID.class),
+                resultSet.getString("nickname"),
+                resultSet.getString("display_name"),
+                resultSet.getString("avatar_url"),
+                resultSet.getObject("team_member_id", UUID.class),
+                TeamMemberRole.fromDatabaseValue(resultSet.getString("member_role")),
+                resultSet.getBoolean("is_starter"),
+                resultSet.getObject("created_at", OffsetDateTime.class),
+                resultSet.getObject("updated_at", OffsetDateTime.class));
+    }
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/service/TournamentRegistrationService.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/service/TournamentRegistrationService.java
@@ -1,0 +1,352 @@
+package si.um.feri.dotaops.backend.tournament.service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import si.um.feri.dotaops.backend.auth.domain.AuthenticatedActor;
+import si.um.feri.dotaops.backend.auth.service.CurrentUserProvider;
+import si.um.feri.dotaops.backend.common.error.ApiException;
+import si.um.feri.dotaops.backend.common.error.BadRequestException;
+import si.um.feri.dotaops.backend.common.error.ConflictException;
+import si.um.feri.dotaops.backend.common.error.ResourceNotFoundException;
+import si.um.feri.dotaops.backend.common.security.DatabaseActorContext;
+import si.um.feri.dotaops.backend.team.domain.Team;
+import si.um.feri.dotaops.backend.team.repository.TeamMemberRepository;
+import si.um.feri.dotaops.backend.team.repository.TeamRepository;
+import si.um.feri.dotaops.backend.tournament.domain.Tournament;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistration;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationStatus;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentStatus;
+import si.um.feri.dotaops.backend.tournament.dto.CreateTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.ReviewTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.TournamentRegistrationResponse;
+import si.um.feri.dotaops.backend.tournament.repository.CreateTournamentRegistrationCommand;
+import si.um.feri.dotaops.backend.tournament.repository.TournamentRegistrationRepository;
+import si.um.feri.dotaops.backend.tournament.repository.TournamentRepository;
+
+@Service
+public class TournamentRegistrationService {
+
+    private final TournamentRegistrationRepository registrationRepository;
+    private final TournamentRepository tournamentRepository;
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final CurrentUserProvider currentUserProvider;
+    private final DatabaseActorContext databaseActorContext;
+
+    public TournamentRegistrationService(
+            TournamentRegistrationRepository registrationRepository,
+            TournamentRepository tournamentRepository,
+            TeamRepository teamRepository,
+            TeamMemberRepository teamMemberRepository,
+            CurrentUserProvider currentUserProvider,
+            DatabaseActorContext databaseActorContext
+    ) {
+        this.registrationRepository = registrationRepository;
+        this.tournamentRepository = tournamentRepository;
+        this.teamRepository = teamRepository;
+        this.teamMemberRepository = teamMemberRepository;
+        this.currentUserProvider = currentUserProvider;
+        this.databaseActorContext = databaseActorContext;
+    }
+
+    @Transactional(readOnly = true)
+    public List<TournamentRegistrationResponse> listOrganizerRegistrations(UUID tournamentId, String requestedStatus) {
+        AuthenticatedActor actor = currentUserProvider.requireActor();
+        ensureTournamentExists(tournamentId);
+        ensureCanManage(actor, tournamentId);
+
+        return registrationRepository.findByTournamentId(tournamentId, parseOptionalStatus(requestedStatus))
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TournamentRegistrationResponse> listTeamRegistrations(UUID teamId) {
+        AuthenticatedActor actor = currentUserProvider.requireActor();
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new ResourceNotFoundException("Team", "id", teamId));
+        ensureCanViewTeamRegistrations(actor, team);
+
+        return registrationRepository.findByTeamId(teamId)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Transactional
+    public TournamentRegistrationResponse registerTeam(UUID tournamentId, CreateTournamentRegistrationRequest request) {
+        AuthenticatedActor actor = currentUserProvider.requireActor();
+        UUID profileId = actor.requireProfileId();
+        Tournament tournament = ensureTournamentExists(tournamentId);
+        Team team = teamRepository.findById(request.teamId())
+                .orElseThrow(() -> new ResourceNotFoundException("Team", "id", request.teamId()));
+
+        ensureCanRegisterTeam(actor, team);
+        ensureRegistrationWindowOpen(tournament);
+        int rosterSize = tournament.settings().teamSize();
+        ensureRosterReady(team.id(), rosterSize);
+        databaseActorContext.apply(actor);
+
+        try {
+            TournamentRegistration registration = registrationRepository.create(
+                    new CreateTournamentRegistrationCommand(
+                            tournament.id(),
+                            team.id(),
+                            profileId,
+                            normalizeOptional(request.message()),
+                            normalizeEmail(request.contactEmail())),
+                    rosterSize);
+
+            return toResponse(registration);
+        } catch (DataIntegrityViolationException exception) {
+            throw registrationConstraintException(exception);
+        }
+    }
+
+    @Transactional
+    public TournamentRegistrationResponse approveRegistration(
+            UUID tournamentId,
+            UUID registrationId,
+            ReviewTournamentRegistrationRequest request
+    ) {
+        return reviewRegistration(
+                tournamentId,
+                registrationId,
+                TournamentRegistrationStatus.APPROVED,
+                request == null ? null : request.seedNumber());
+    }
+
+    @Transactional
+    public TournamentRegistrationResponse rejectRegistration(UUID tournamentId, UUID registrationId) {
+        return reviewRegistration(tournamentId, registrationId, TournamentRegistrationStatus.REJECTED, null);
+    }
+
+    @Transactional
+    public TournamentRegistrationResponse waitlistRegistration(UUID tournamentId, UUID registrationId) {
+        return reviewRegistration(tournamentId, registrationId, TournamentRegistrationStatus.WAITLISTED, null);
+    }
+
+    @Transactional
+    public TournamentRegistrationResponse checkInRegistration(UUID tournamentId, UUID registrationId) {
+        AuthenticatedActor actor = currentUserProvider.requireActor();
+        Tournament tournament = ensureTournamentExists(tournamentId);
+        TournamentRegistration registration = findRegistration(tournamentId, registrationId);
+        ensureCanCheckIn(actor, registration, tournamentId);
+        ensureCheckInAllowed(tournament, registration);
+        databaseActorContext.apply(actor);
+
+        return registrationRepository.checkIn(registrationId, tournamentId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new ResourceNotFoundException("Tournament registration", "id", registrationId));
+    }
+
+    private TournamentRegistrationResponse reviewRegistration(
+            UUID tournamentId,
+            UUID registrationId,
+            TournamentRegistrationStatus status,
+            Integer seedNumber
+    ) {
+        AuthenticatedActor actor = currentUserProvider.requireActor();
+        Tournament tournament = ensureTournamentExists(tournamentId);
+        TournamentRegistration existing = findRegistration(tournamentId, registrationId);
+        ensureCanManage(actor, tournamentId);
+        validateReview(status, seedNumber, tournament, existing);
+        databaseActorContext.apply(actor);
+
+        try {
+            return registrationRepository.updateStatus(
+                            registrationId,
+                            tournamentId,
+                            status,
+                            actor.requireProfileId(),
+                            seedNumber)
+                    .map(this::toResponse)
+                    .orElseThrow(() -> new ResourceNotFoundException("Tournament registration", "id", registrationId));
+        } catch (DataIntegrityViolationException exception) {
+            throw registrationConstraintException(exception);
+        }
+    }
+
+    private Tournament ensureTournamentExists(UUID tournamentId) {
+        return tournamentRepository.findById(tournamentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Tournament", "id", tournamentId));
+    }
+
+    private TournamentRegistration findRegistration(UUID tournamentId, UUID registrationId) {
+        return registrationRepository.findByIdAndTournamentId(registrationId, tournamentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Tournament registration", "id", registrationId));
+    }
+
+    private void ensureCanRegisterTeam(AuthenticatedActor actor, Team team) {
+        if (actor.requireProfileId().equals(team.captainProfileId())) {
+            return;
+        }
+
+        throw new AccessDeniedException("Only the team captain can register this team for a tournament.");
+    }
+
+    private void ensureCanViewTeamRegistrations(AuthenticatedActor actor, Team team) {
+        UUID profileId = actor.requireProfileId();
+        if (actor.isAdmin()
+                || profileId.equals(team.captainProfileId())
+                || teamMemberRepository.existsActive(team.id(), profileId)) {
+            return;
+        }
+
+        throw new AccessDeniedException("Only active team members can view this team's tournament registrations.");
+    }
+
+    private void ensureCanManage(AuthenticatedActor actor, UUID tournamentId) {
+        UUID profileId = actor.requireProfileId();
+        if (tournamentRepository.canManage(tournamentId, profileId, actor.isAdmin())) {
+            return;
+        }
+
+        throw new AccessDeniedException("Only the tournament owner, tournament organizers, or admins can manage registrations.");
+    }
+
+    private void ensureCanCheckIn(AuthenticatedActor actor, TournamentRegistration registration, UUID tournamentId) {
+        UUID profileId = actor.requireProfileId();
+        if (actor.isAdmin()
+                || profileId.equals(registration.captainProfileId())
+                || tournamentRepository.canManage(tournamentId, profileId, actor.isAdmin())) {
+            return;
+        }
+
+        throw new AccessDeniedException("Only the registered captain or tournament organizer can check in this team.");
+    }
+
+    private void ensureRegistrationWindowOpen(Tournament tournament) {
+        if (tournament.status() == TournamentStatus.DRAFT
+                || tournament.status() == TournamentStatus.LIVE
+                || tournament.status() == TournamentStatus.ARCHIVED) {
+            throw new ConflictException("Tournament is not open for registrations.");
+        }
+
+        if (tournament.status() == TournamentStatus.FINISHED) {
+            throw new ConflictException("Finished tournaments do not accept registrations.");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        if (tournament.registrationOpensAt() != null && now.isBefore(tournament.registrationOpensAt())) {
+            throw new BadRequestException("Tournament registration is not open yet.");
+        }
+
+        if (tournament.registrationClosesAt() != null && now.isAfter(tournament.registrationClosesAt())) {
+            throw new BadRequestException("Tournament registration is closed.");
+        }
+    }
+
+    private void ensureRosterReady(UUID teamId, int requiredRosterSize) {
+        int activeRosterMembers = registrationRepository.countActiveRosterMembers(teamId);
+        if (activeRosterMembers < requiredRosterSize) {
+            throw new BadRequestException("Team must have at least %d active roster members before registration."
+                    .formatted(requiredRosterSize));
+        }
+    }
+
+    private void validateReview(
+            TournamentRegistrationStatus status,
+            Integer seedNumber,
+            Tournament tournament,
+            TournamentRegistration registration
+    ) {
+        if (registration.checkedInAt() != null) {
+            throw new ConflictException("Checked-in registrations can no longer be reviewed.");
+        }
+
+        if (status == TournamentRegistrationStatus.APPROVED) {
+            long approvedCount = registrationRepository.countApprovedRegistrations(tournament.id(), registration.id());
+            if (approvedCount >= tournament.maxTeams()) {
+                throw new ConflictException("Tournament already has the maximum number of approved teams.");
+            }
+
+            if (seedNumber != null && seedNumber < 1) {
+                throw new BadRequestException("Registration seed number must be positive.");
+            }
+            return;
+        }
+
+        if (seedNumber != null) {
+            throw new BadRequestException("Seed number is only allowed when approving a registration.");
+        }
+    }
+
+    private void ensureCheckInAllowed(Tournament tournament, TournamentRegistration registration) {
+        if (registration.status() != TournamentRegistrationStatus.APPROVED) {
+            throw new ConflictException("Only approved registrations can check in.");
+        }
+
+        if (!tournament.settings().checkInEnabled()) {
+            throw new ConflictException("Check-in is not enabled for this tournament.");
+        }
+
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        if (tournament.checkInOpensAt() != null && now.isBefore(tournament.checkInOpensAt())) {
+            throw new BadRequestException("Tournament check-in is not open yet.");
+        }
+
+        if (tournament.checkInClosesAt() != null && now.isAfter(tournament.checkInClosesAt())) {
+            throw new BadRequestException("Tournament check-in is closed.");
+        }
+    }
+
+    private TournamentRegistrationResponse toResponse(TournamentRegistration registration) {
+        return TournamentRegistrationResponse.from(
+                registration,
+                registrationRepository.findMembers(registration.id()));
+    }
+
+    private TournamentRegistrationStatus parseOptionalStatus(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        try {
+            return TournamentRegistrationStatus.fromDatabaseValue(value);
+        } catch (IllegalArgumentException exception) {
+            throw new BadRequestException("Unsupported tournament registration status.");
+        }
+    }
+
+    private String normalizeOptional(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return value.trim();
+    }
+
+    private String normalizeEmail(String value) {
+        String normalized = normalizeOptional(value);
+        return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private ApiException registrationConstraintException(DataIntegrityViolationException exception) {
+        String message = exception.getMostSpecificCause().getMessage();
+
+        if (message != null && message.contains("tournament_registrations_tournament_id_team_id_key")) {
+            return new ConflictException("Team is already registered for this tournament.");
+        }
+
+        if (message != null && message.contains("tournament_registrations_seed_idx")) {
+            return new BadRequestException("Registration seed number is already in use for this tournament.");
+        }
+
+        if (message != null && message.contains("tournament_registration_members_validate_starters")) {
+            return new BadRequestException("A tournament registration can have at most five starters.");
+        }
+
+        return new BadRequestException("Tournament registration data violates a database constraint.");
+    }
+}

--- a/backend/src/main/java/si/um/feri/dotaops/backend/tournament/web/TournamentRegistrationController.java
+++ b/backend/src/main/java/si/um/feri/dotaops/backend/tournament/web/TournamentRegistrationController.java
@@ -1,0 +1,91 @@
+package si.um.feri.dotaops.backend.tournament.web;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import si.um.feri.dotaops.backend.common.api.ApiResponse;
+import si.um.feri.dotaops.backend.tournament.dto.CreateTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.ReviewTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.TournamentRegistrationResponse;
+import si.um.feri.dotaops.backend.tournament.service.TournamentRegistrationService;
+
+@RestController
+@RequestMapping("/api")
+public class TournamentRegistrationController {
+
+    private final TournamentRegistrationService registrationService;
+
+    public TournamentRegistrationController(TournamentRegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    @PostMapping("/tournaments/{tournamentId}/registrations")
+    ResponseEntity<ApiResponse<TournamentRegistrationResponse>> registerTeam(
+            @PathVariable UUID tournamentId,
+            @Valid @RequestBody CreateTournamentRegistrationRequest request
+    ) {
+        TournamentRegistrationResponse response = registrationService.registerTeam(tournamentId, request);
+
+        return ResponseEntity
+                .created(URI.create("/api/tournaments/" + tournamentId + "/registrations/" + response.id()))
+                .body(ApiResponse.of(response));
+    }
+
+    @PostMapping("/tournaments/{tournamentId}/registrations/{registrationId}/check-in")
+    ApiResponse<TournamentRegistrationResponse> checkInRegistration(
+            @PathVariable UUID tournamentId,
+            @PathVariable UUID registrationId
+    ) {
+        return ApiResponse.of(registrationService.checkInRegistration(tournamentId, registrationId));
+    }
+
+    @GetMapping("/teams/{teamId}/tournament-registrations")
+    ApiResponse<List<TournamentRegistrationResponse>> listTeamRegistrations(@PathVariable UUID teamId) {
+        return ApiResponse.of(registrationService.listTeamRegistrations(teamId));
+    }
+
+    @GetMapping("/organizer/tournaments/{tournamentId}/registrations")
+    ApiResponse<List<TournamentRegistrationResponse>> listOrganizerRegistrations(
+            @PathVariable UUID tournamentId,
+            @RequestParam(required = false) String status
+    ) {
+        return ApiResponse.of(registrationService.listOrganizerRegistrations(tournamentId, status));
+    }
+
+    @PostMapping("/organizer/tournaments/{tournamentId}/registrations/{registrationId}/approve")
+    ApiResponse<TournamentRegistrationResponse> approveRegistration(
+            @PathVariable UUID tournamentId,
+            @PathVariable UUID registrationId,
+            @Valid @RequestBody(required = false) ReviewTournamentRegistrationRequest request
+    ) {
+        return ApiResponse.of(registrationService.approveRegistration(tournamentId, registrationId, request));
+    }
+
+    @PostMapping("/organizer/tournaments/{tournamentId}/registrations/{registrationId}/reject")
+    ApiResponse<TournamentRegistrationResponse> rejectRegistration(
+            @PathVariable UUID tournamentId,
+            @PathVariable UUID registrationId
+    ) {
+        return ApiResponse.of(registrationService.rejectRegistration(tournamentId, registrationId));
+    }
+
+    @PostMapping("/organizer/tournaments/{tournamentId}/registrations/{registrationId}/waitlist")
+    ApiResponse<TournamentRegistrationResponse> waitlistRegistration(
+            @PathVariable UUID tournamentId,
+            @PathVariable UUID registrationId
+    ) {
+        return ApiResponse.of(registrationService.waitlistRegistration(tournamentId, registrationId));
+    }
+}

--- a/backend/src/main/resources/db/migration/V13__allow_team_members_read_registration_status.sql
+++ b/backend/src/main/resources/db/migration/V13__allow_team_members_read_registration_status.sql
@@ -1,0 +1,60 @@
+-- Let active team members read their team's tournament registration status
+-- without broadening registration write permissions.
+
+create or replace function private.is_active_team_member(target_team_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.team_members tm
+    where tm.team_id = target_team_id
+      and tm.profile_id = private.current_profile_id()
+      and tm.is_active = true
+  )
+$$;
+
+create or replace function private.can_read_registration(target_registration_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.tournament_registrations tr
+    where tr.id = target_registration_id
+      and (
+        private.can_manage_tournament(tr.tournament_id)
+        or private.is_team_captain(tr.team_id)
+        or private.is_active_team_member(tr.team_id)
+        or (
+          tr.status = 'approved'
+          and private.can_read_tournament(tr.tournament_id)
+        )
+      )
+  )
+$$;
+
+drop policy if exists "registrations are readable when relevant" on public.tournament_registrations;
+
+create policy "registrations are readable when relevant"
+on public.tournament_registrations for select
+to anon, authenticated
+using (
+  private.can_manage_tournament(tournament_id)
+  or private.is_team_captain(team_id)
+  or private.is_active_team_member(team_id)
+  or (
+    status = 'approved'::public.dotaops_registration_status
+    and private.can_read_tournament(tournament_id)
+  )
+);
+
+comment on policy "registrations are readable when relevant"
+on public.tournament_registrations
+is 'Organizers, team captains, and active team members can read relevant registration statuses; approved public registrations remain public-safe.';

--- a/backend/src/test/java/si/um/feri/dotaops/backend/tournament/service/TournamentRegistrationServiceTest.java
+++ b/backend/src/test/java/si/um/feri/dotaops/backend/tournament/service/TournamentRegistrationServiceTest.java
@@ -1,0 +1,487 @@
+package si.um.feri.dotaops.backend.tournament.service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+
+import si.um.feri.dotaops.backend.auth.domain.AuthenticatedActor;
+import si.um.feri.dotaops.backend.auth.domain.ProfileRole;
+import si.um.feri.dotaops.backend.auth.service.CurrentUserProvider;
+import si.um.feri.dotaops.backend.common.error.BadRequestException;
+import si.um.feri.dotaops.backend.common.error.ConflictException;
+import si.um.feri.dotaops.backend.common.security.DatabaseActorContext;
+import si.um.feri.dotaops.backend.team.domain.Team;
+import si.um.feri.dotaops.backend.team.domain.TeamMemberRole;
+import si.um.feri.dotaops.backend.team.repository.TeamMemberRepository;
+import si.um.feri.dotaops.backend.team.repository.TeamRepository;
+import si.um.feri.dotaops.backend.tournament.domain.Tournament;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentFormat;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistration;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationMember;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentRegistrationStatus;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentSettings;
+import si.um.feri.dotaops.backend.tournament.domain.TournamentStatus;
+import si.um.feri.dotaops.backend.tournament.dto.CreateTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.ReviewTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.repository.CreateTournamentRegistrationCommand;
+import si.um.feri.dotaops.backend.tournament.repository.TournamentRegistrationRepository;
+import si.um.feri.dotaops.backend.tournament.repository.TournamentRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TournamentRegistrationServiceTest {
+
+    private static final UUID AUTH_USER_ID = UUID.fromString("11111111-1111-4111-8111-111111111111");
+    private static final UUID CAPTAIN_PROFILE_ID = UUID.fromString("22222222-2222-4222-8222-222222222222");
+    private static final UUID OTHER_PROFILE_ID = UUID.fromString("33333333-3333-4333-8333-333333333333");
+    private static final UUID ORGANIZER_PROFILE_ID = UUID.fromString("77777777-7777-4777-8777-777777777777");
+    private static final UUID TOURNAMENT_ID = UUID.fromString("44444444-4444-4444-8444-444444444444");
+    private static final UUID TEAM_ID = UUID.fromString("55555555-5555-4555-8555-555555555555");
+    private static final UUID REGISTRATION_ID = UUID.fromString("66666666-6666-4666-8666-666666666666");
+    private static final OffsetDateTime NOW = OffsetDateTime.now(java.time.ZoneOffset.UTC);
+
+    private final TournamentRegistrationRepository registrationRepository = mock(TournamentRegistrationRepository.class);
+    private final TournamentRepository tournamentRepository = mock(TournamentRepository.class);
+    private final TeamRepository teamRepository = mock(TeamRepository.class);
+    private final TeamMemberRepository teamMemberRepository = mock(TeamMemberRepository.class);
+    private final CurrentUserProvider currentUserProvider = mock(CurrentUserProvider.class);
+    private final DatabaseActorContext databaseActorContext = mock(DatabaseActorContext.class);
+    private final TournamentRegistrationService service = new TournamentRegistrationService(
+            registrationRepository,
+            tournamentRepository,
+            teamRepository,
+            teamMemberRepository,
+            currentUserProvider,
+            databaseActorContext);
+
+    @Test
+    void captainCanRegisterTeamAndRosterSnapshotUsesTournamentTeamSize() {
+        AuthenticatedActor actor = actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER);
+        when(currentUserProvider.requireActor()).thenReturn(actor);
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(registrationRepository.countActiveRosterMembers(TEAM_ID)).thenReturn(5);
+        when(registrationRepository.create(any(CreateTournamentRegistrationCommand.class), eq(5)))
+                .thenReturn(registration(TournamentRegistrationStatus.PENDING));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.registerTeam(TOURNAMENT_ID, new CreateTournamentRegistrationRequest(
+                TEAM_ID,
+                "Ready",
+                "Captain@Example.test"));
+
+        assertThat(response.id()).isEqualTo(REGISTRATION_ID);
+        assertThat(response.status()).isEqualTo("pending");
+        verify(databaseActorContext).apply(actor);
+        verify(registrationRepository).create(any(CreateTournamentRegistrationCommand.class), eq(5));
+    }
+
+    @Test
+    void nonCaptainCannotRegisterTeam() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(OTHER_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+
+        assertThatThrownBy(() -> service.registerTeam(TOURNAMENT_ID, new CreateTournamentRegistrationRequest(
+                TEAM_ID,
+                null,
+                null)))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Only the team captain can register this team for a tournament.");
+    }
+
+    @Test
+    void duplicateTeamRegistrationIsRejected() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(registrationRepository.countActiveRosterMembers(TEAM_ID)).thenReturn(5);
+        when(registrationRepository.create(any(CreateTournamentRegistrationCommand.class), eq(5)))
+                .thenThrow(new DataIntegrityViolationException(
+                        "duplicate",
+                        new RuntimeException("tournament_registrations_tournament_id_team_id_key")));
+
+        assertThatThrownBy(() -> service.registerTeam(TOURNAMENT_ID, new CreateTournamentRegistrationRequest(
+                TEAM_ID,
+                null,
+                null)))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Team is already registered for this tournament.");
+    }
+
+    @Test
+    void registrationRequiresFullActiveRoster() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(registrationRepository.countActiveRosterMembers(TEAM_ID)).thenReturn(4);
+
+        assertThatThrownBy(() -> service.registerTeam(TOURNAMENT_ID, new CreateTournamentRegistrationRequest(
+                TEAM_ID,
+                null,
+                null)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Team must have at least 5 active roster members before registration.");
+    }
+
+    @Test
+    void teamRegistrationStatusUsesStoredRosterSnapshotAfterRosterChanges() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(registrationRepository.findByTeamId(TEAM_ID))
+                .thenReturn(List.of(registration(TournamentRegistrationStatus.PENDING)));
+        when(registrationRepository.findMembers(REGISTRATION_ID))
+                .thenReturn(List.of(snapshotMember(CAPTAIN_PROFILE_ID)));
+
+        var response = service.listTeamRegistrations(TEAM_ID);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().members()).hasSize(1);
+        assertThat(response.getFirst().members().getFirst().profileId()).isEqualTo(CAPTAIN_PROFILE_ID);
+        verify(registrationRepository, never()).create(any(CreateTournamentRegistrationCommand.class), eq(5));
+    }
+
+    @Test
+    void organizerCanApproveRegistration() {
+        mockOrganizerReview(TournamentRegistrationStatus.PENDING);
+        when(registrationRepository.countApprovedRegistrations(TOURNAMENT_ID, REGISTRATION_ID)).thenReturn(0L);
+        when(registrationRepository.updateStatus(
+                REGISTRATION_ID,
+                TOURNAMENT_ID,
+                TournamentRegistrationStatus.APPROVED,
+                ORGANIZER_PROFILE_ID,
+                1))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.APPROVED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.approveRegistration(
+                TOURNAMENT_ID,
+                REGISTRATION_ID,
+                new ReviewTournamentRegistrationRequest(1));
+
+        assertThat(response.status()).isEqualTo("approved");
+        verify(databaseActorContext).apply(actor(ORGANIZER_PROFILE_ID, ProfileRole.ORGANIZER));
+    }
+
+    @Test
+    void organizerCanRejectRegistration() {
+        mockOrganizerReview(TournamentRegistrationStatus.PENDING);
+        when(registrationRepository.updateStatus(
+                REGISTRATION_ID,
+                TOURNAMENT_ID,
+                TournamentRegistrationStatus.REJECTED,
+                ORGANIZER_PROFILE_ID,
+                null))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.REJECTED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.rejectRegistration(TOURNAMENT_ID, REGISTRATION_ID);
+
+        assertThat(response.status()).isEqualTo("rejected");
+    }
+
+    @Test
+    void organizerCanWaitlistRegistration() {
+        mockOrganizerReview(TournamentRegistrationStatus.PENDING);
+        when(registrationRepository.updateStatus(
+                REGISTRATION_ID,
+                TOURNAMENT_ID,
+                TournamentRegistrationStatus.WAITLISTED,
+                ORGANIZER_PROFILE_ID,
+                null))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.WAITLISTED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.waitlistRegistration(TOURNAMENT_ID, REGISTRATION_ID);
+
+        assertThat(response.status()).isEqualTo("waitlisted");
+    }
+
+    @Test
+    void nonOrganizerCannotChangeRegistrationStatus() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(OTHER_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.PENDING)));
+        when(tournamentRepository.canManage(TOURNAMENT_ID, OTHER_PROFILE_ID, false)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.rejectRegistration(TOURNAMENT_ID, REGISTRATION_ID))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Only the tournament owner, tournament organizers, or admins can manage registrations.");
+    }
+
+    @Test
+    void approveRejectsWhenTournamentIsAlreadyFull() {
+        mockOrganizerReview(TournamentRegistrationStatus.PENDING);
+        when(registrationRepository.countApprovedRegistrations(TOURNAMENT_ID, REGISTRATION_ID)).thenReturn(8L);
+
+        assertThatThrownBy(() -> service.approveRegistration(
+                TOURNAMENT_ID,
+                REGISTRATION_ID,
+                new ReviewTournamentRegistrationRequest(1)))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Tournament already has the maximum number of approved teams.");
+    }
+
+    @Test
+    void approvedCaptainCanCheckInWhenWindowIsOpen() {
+        AuthenticatedActor actor = actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER);
+        when(currentUserProvider.requireActor()).thenReturn(actor);
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(tournament(
+                TournamentStatus.PUBLISHED,
+                settings(true),
+                NOW.minusHours(1),
+                NOW.plusHours(1))));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.APPROVED)));
+        when(registrationRepository.checkIn(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.APPROVED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.checkInRegistration(TOURNAMENT_ID, REGISTRATION_ID);
+
+        assertThat(response.status()).isEqualTo("approved");
+        verify(databaseActorContext).apply(actor);
+    }
+
+    @Test
+    void checkInOutsideWindowIsRejected() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(tournament(
+                TournamentStatus.PUBLISHED,
+                settings(true),
+                NOW.plusHours(1),
+                NOW.plusHours(2))));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.APPROVED)));
+
+        assertThatThrownBy(() -> service.checkInRegistration(TOURNAMENT_ID, REGISTRATION_ID))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("Tournament check-in is not open yet.");
+    }
+
+    @Test
+    void rejectedRegistrationCannotCheckIn() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(tournament(
+                TournamentStatus.PUBLISHED,
+                settings(true),
+                NOW.minusHours(1),
+                NOW.plusHours(1))));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.REJECTED)));
+
+        assertThatThrownBy(() -> service.checkInRegistration(TOURNAMENT_ID, REGISTRATION_ID))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Only approved registrations can check in.");
+    }
+
+    @Test
+    void organizerCanSeeRegistrationsForManagedTournament() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(ORGANIZER_PROFILE_ID, ProfileRole.ORGANIZER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(tournamentRepository.canManage(TOURNAMENT_ID, ORGANIZER_PROFILE_ID, false)).thenReturn(true);
+        when(registrationRepository.findByTournamentId(TOURNAMENT_ID, TournamentRegistrationStatus.PENDING))
+                .thenReturn(List.of(registration(TournamentRegistrationStatus.PENDING)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.listOrganizerRegistrations(TOURNAMENT_ID, "pending");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().status()).isEqualTo("pending");
+    }
+
+    @Test
+    void teamCaptainCanSeeTeamRegistrationStatus() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(CAPTAIN_PROFILE_ID, ProfileRole.PLAYER));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(registrationRepository.findByTeamId(TEAM_ID))
+                .thenReturn(List.of(registration(TournamentRegistrationStatus.WAITLISTED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.listTeamRegistrations(TEAM_ID);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().status()).isEqualTo("waitlisted");
+    }
+
+    @Test
+    void activePlayerCanSeeTeamRegistrationStatus() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(OTHER_PROFILE_ID, ProfileRole.PLAYER));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(teamMemberRepository.existsActive(TEAM_ID, OTHER_PROFILE_ID)).thenReturn(true);
+        when(registrationRepository.findByTeamId(TEAM_ID))
+                .thenReturn(List.of(registration(TournamentRegistrationStatus.APPROVED)));
+        when(registrationRepository.findMembers(REGISTRATION_ID)).thenReturn(List.of());
+
+        var response = service.listTeamRegistrations(TEAM_ID);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().status()).isEqualTo("approved");
+    }
+
+    @Test
+    void nonMemberCannotSeeTeamRegistrationStatus() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(OTHER_PROFILE_ID, ProfileRole.PLAYER));
+        when(teamRepository.findById(TEAM_ID)).thenReturn(Optional.of(team(CAPTAIN_PROFILE_ID)));
+        when(teamMemberRepository.existsActive(TEAM_ID, OTHER_PROFILE_ID)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.listTeamRegistrations(TEAM_ID))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Only active team members can view this team's tournament registrations.");
+    }
+
+    @Test
+    void checkedInRegistrationCannotBeReviewedAgain() {
+        when(currentUserProvider.requireActor()).thenReturn(actor(ORGANIZER_PROFILE_ID, ProfileRole.ORGANIZER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(TournamentRegistrationStatus.APPROVED, NOW.minusMinutes(5))));
+        when(tournamentRepository.canManage(TOURNAMENT_ID, ORGANIZER_PROFILE_ID, false)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.rejectRegistration(TOURNAMENT_ID, REGISTRATION_ID))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Checked-in registrations can no longer be reviewed.");
+    }
+
+    private void mockOrganizerReview(TournamentRegistrationStatus currentStatus) {
+        when(currentUserProvider.requireActor()).thenReturn(actor(ORGANIZER_PROFILE_ID, ProfileRole.ORGANIZER));
+        when(tournamentRepository.findById(TOURNAMENT_ID)).thenReturn(Optional.of(openTournament()));
+        when(registrationRepository.findByIdAndTournamentId(REGISTRATION_ID, TOURNAMENT_ID))
+                .thenReturn(Optional.of(registration(currentStatus)));
+        when(tournamentRepository.canManage(TOURNAMENT_ID, ORGANIZER_PROFILE_ID, false)).thenReturn(true);
+    }
+
+    private static AuthenticatedActor actor(UUID profileId, ProfileRole role) {
+        return new AuthenticatedActor(
+                AUTH_USER_ID,
+                profileId,
+                "user@example.test",
+                null,
+                role);
+    }
+
+    private static Team team(UUID captainProfileId) {
+        return new Team(
+                TEAM_ID,
+                "Radiant Five",
+                "R5",
+                "radiant-five",
+                captainProfileId,
+                "Captain",
+                "EU",
+                null,
+                null,
+                AUTH_USER_ID,
+                NOW.minusDays(10),
+                NOW.minusDays(1));
+    }
+
+    private static TournamentSettings settings(boolean checkInEnabled) {
+        return new TournamentSettings(
+                8,
+                2,
+                5,
+                1,
+                TournamentFormat.SINGLE_ELIMINATION,
+                checkInEnabled,
+                true);
+    }
+
+    private static Tournament openTournament() {
+        return tournament(
+                TournamentStatus.PUBLISHED,
+                settings(false),
+                NOW.minusDays(1),
+                NOW.plusDays(1));
+    }
+
+    private static Tournament tournament(
+            TournamentStatus status,
+            TournamentSettings settings,
+            OffsetDateTime checkInOpensAt,
+            OffsetDateTime checkInClosesAt
+    ) {
+        return new Tournament(
+                TOURNAMENT_ID,
+                "mid-wars-open",
+                "Mid Wars Open",
+                status,
+                settings.format(),
+                ORGANIZER_PROFILE_ID,
+                "Organizer",
+                "Qualifier",
+                "Rules",
+                "TBD",
+                settings.maxTeams(),
+                NOW.plusDays(2),
+                NOW.plusDays(3),
+                NOW.minusDays(2),
+                NOW.plusDays(1),
+                true,
+                AUTH_USER_ID,
+                "UTC",
+                checkInOpensAt,
+                checkInClosesAt,
+                NOW.minusDays(5),
+                settings,
+                0,
+                NOW.minusDays(10),
+                NOW.minusDays(1));
+    }
+
+    private static TournamentRegistration registration(TournamentRegistrationStatus status) {
+        return registration(status, null);
+    }
+
+    private static TournamentRegistration registration(TournamentRegistrationStatus status, OffsetDateTime checkedInAt) {
+        return new TournamentRegistration(
+                REGISTRATION_ID,
+                TOURNAMENT_ID,
+                "mid-wars-open",
+                "Mid Wars Open",
+                TEAM_ID,
+                "Radiant Five",
+                "R5",
+                "radiant-five",
+                CAPTAIN_PROFILE_ID,
+                "Captain",
+                status,
+                "Ready",
+                null,
+                null,
+                null,
+                null,
+                checkedInAt,
+                "captain@example.test",
+                NOW.minusHours(2),
+                NOW.minusHours(1));
+    }
+
+    private static TournamentRegistrationMember snapshotMember(UUID profileId) {
+        return new TournamentRegistrationMember(
+                UUID.fromString("99999999-9999-4999-8999-999999999999"),
+                REGISTRATION_ID,
+                profileId,
+                "captain",
+                "Captain",
+                null,
+                UUID.fromString("88888888-8888-4888-8888-888888888888"),
+                TeamMemberRole.CARRY,
+                true,
+                NOW.minusHours(2),
+                NOW.minusHours(2));
+    }
+}

--- a/backend/src/test/java/si/um/feri/dotaops/backend/tournament/web/TournamentRegistrationControllerTest.java
+++ b/backend/src/test/java/si/um/feri/dotaops/backend/tournament/web/TournamentRegistrationControllerTest.java
@@ -1,0 +1,197 @@
+package si.um.feri.dotaops.backend.tournament.web;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import si.um.feri.dotaops.backend.BackendApplication;
+import si.um.feri.dotaops.backend.auth.domain.AuthenticatedProfile;
+import si.um.feri.dotaops.backend.auth.domain.ProfileRole;
+import si.um.feri.dotaops.backend.auth.repository.AuthenticatedProfileRepository;
+import si.um.feri.dotaops.backend.auth.service.SupabaseJwtTestSupport;
+import si.um.feri.dotaops.backend.tournament.dto.CreateTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.ReviewTournamentRegistrationRequest;
+import si.um.feri.dotaops.backend.tournament.dto.TournamentRegistrationResponse;
+import si.um.feri.dotaops.backend.tournament.service.TournamentRegistrationService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = {
+        BackendApplication.class,
+        TournamentRegistrationControllerTest.TournamentRegistrationControllerTestConfig.class
+})
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "dotaops.supabase.auth.jwt-secret=" + SupabaseJwtTestSupport.SECRET,
+        "dotaops.supabase.auth.issuer=" + SupabaseJwtTestSupport.ISSUER,
+        "dotaops.supabase.auth.audience=" + SupabaseJwtTestSupport.AUDIENCE,
+        "dotaops.steam.session.jwt-secret=" + SupabaseJwtTestSupport.SECRET,
+        "dotaops.steam.session.ttl=1h"
+})
+class TournamentRegistrationControllerTest {
+
+    private static final UUID AUTH_USER_ID = UUID.fromString("11111111-1111-4111-8111-111111111111");
+    private static final UUID PROFILE_ID = UUID.fromString("22222222-2222-4222-8222-222222222222");
+    private static final UUID TOURNAMENT_ID = UUID.fromString("33333333-3333-4333-8333-333333333333");
+    private static final UUID TEAM_ID = UUID.fromString("44444444-4444-4444-8444-444444444444");
+    private static final UUID REGISTRATION_ID = UUID.fromString("55555555-5555-4555-8555-555555555555");
+    private static final OffsetDateTime NOW = OffsetDateTime.parse("2026-06-01T18:00:00Z");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TournamentRegistrationService registrationService;
+
+    @Autowired
+    private AuthenticatedProfileRepository authenticatedProfileRepository;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.reset(registrationService, authenticatedProfileRepository);
+        when(authenticatedProfileRepository.findByAuthUserId(AUTH_USER_ID))
+                .thenReturn(Optional.of(authenticatedProfile()));
+    }
+
+    @Test
+    void registerTeamRequiresAuthentication() throws Exception {
+        mockMvc.perform(post("/api/tournaments/" + TOURNAMENT_ID + "/registrations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "teamId": "%s"
+                                }
+                                """.formatted(TEAM_ID)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void registerTeamReturnsCreatedRegistration() throws Exception {
+        when(registrationService.registerTeam(eq(TOURNAMENT_ID), any(CreateTournamentRegistrationRequest.class)))
+                .thenReturn(response("pending"));
+
+        mockMvc.perform(post("/api/tournaments/" + TOURNAMENT_ID + "/registrations")
+                        .header("Authorization", bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "teamId": "%s",
+                                  "message": "Ready",
+                                  "contactEmail": "captain@example.test"
+                                }
+                                """.formatted(TEAM_ID)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(
+                        "Location",
+                        "/api/tournaments/" + TOURNAMENT_ID + "/registrations/" + REGISTRATION_ID))
+                .andExpect(jsonPath("$.data.status").value("pending"))
+                .andExpect(jsonPath("$.data.teamId").value(TEAM_ID.toString()));
+    }
+
+    @Test
+    void teamRegistrationStatusRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/teams/" + TEAM_ID + "/tournament-registrations"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @Test
+    void organizerApproveRouteDelegatesToService() throws Exception {
+        when(registrationService.approveRegistration(
+                eq(TOURNAMENT_ID),
+                eq(REGISTRATION_ID),
+                any(ReviewTournamentRegistrationRequest.class)))
+                .thenReturn(response("approved"));
+
+        mockMvc.perform(post("/api/organizer/tournaments/" + TOURNAMENT_ID
+                        + "/registrations/" + REGISTRATION_ID + "/approve")
+                        .header("Authorization", bearerToken())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "seedNumber": 1
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("approved"));
+    }
+
+    private static String bearerToken() throws Exception {
+        return "Bearer " + SupabaseJwtTestSupport.token(AUTH_USER_ID, Instant.now());
+    }
+
+    private static AuthenticatedProfile authenticatedProfile() {
+        return new AuthenticatedProfile(
+                PROFILE_ID,
+                AUTH_USER_ID,
+                "Captain",
+                ProfileRole.PLAYER);
+    }
+
+    private static TournamentRegistrationResponse response(String status) {
+        return new TournamentRegistrationResponse(
+                REGISTRATION_ID,
+                TOURNAMENT_ID,
+                "mid-wars-open",
+                "Mid Wars Open",
+                TEAM_ID,
+                "Radiant Five",
+                "R5",
+                "radiant-five",
+                PROFILE_ID,
+                "Captain",
+                status,
+                "Ready",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "captain@example.test",
+                List.of(),
+                NOW.minusHours(1),
+                NOW);
+    }
+
+    @TestConfiguration
+    static class TournamentRegistrationControllerTestConfig {
+
+        @Bean
+        @Primary
+        TournamentRegistrationService registrationService() {
+            return Mockito.mock(TournamentRegistrationService.class);
+        }
+
+        @Bean
+        @Primary
+        AuthenticatedProfileRepository authenticatedProfileRepository() {
+            return Mockito.mock(AuthenticatedProfileRepository.class);
+        }
+    }
+}


### PR DESCRIPTION
Implemented BE/DB-12 tournament team registration flow.

Added backend support for:
- team captain tournament registration
- automatic roster snapshot creation
- duplicate registration prevention
- organizer approve/reject/waitlist actions
- registration check-in with time window validation
- private team registration status visibility
- organizer registration listing

Authorization model was kept simple for iteration 2:
- organizer manages tournament registrations
- team_captain registers the team
- player can view relevant team registration status
- owner is treated as primary organizer
- referee and analyst are not used in this flow yet

Added unit/controller tests covering registration, duplicate prevention, snapshot stability, organizer-only status changes, check-in validation and status visibility.

Tests:
185 tests run, 0 failures, 0 errors, 19 skipped.