### PR TITLE
Implementiran FE-07 vmesnik za skupine in lestvice

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10005,3 +10005,448 @@ textarea:focus {
     justify-content: flex-start;
   }
 }
+
+.groups-standings-panel {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
+  overflow: hidden;
+}
+
+.groups-standings-summary,
+.org-groups-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.org-groups-summary {
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+.groups-standings-summary-card,
+.org-groups-summary-card {
+  display: grid;
+  gap: 7px;
+  min-height: 106px;
+  padding: 16px;
+}
+
+.groups-standings-summary-card svg,
+.org-groups-summary-card svg {
+  color: var(--ops-primary);
+}
+
+.groups-standings-summary-card span,
+.org-groups-summary-card span,
+.groups-standings-rule span,
+.org-groups-command-card label span {
+  color: var(--ops-muted-strong);
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.groups-standings-summary-card strong,
+.org-groups-summary-card strong {
+  color: var(--ops-text);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 1.45rem;
+}
+
+.org-groups-summary-card.is-cyan svg,
+.org-groups-summary-card.is-cyan strong {
+  color: var(--ops-cyan);
+}
+
+.org-groups-summary-card.is-gold svg,
+.org-groups-summary-card.is-gold strong {
+  color: var(--ops-secondary);
+}
+
+.org-groups-summary-card.is-green svg,
+.org-groups-summary-card.is-green strong {
+  color: var(--ops-green);
+}
+
+.org-groups-summary-card.is-red svg,
+.org-groups-summary-card.is-red strong {
+  color: var(--ops-primary);
+}
+
+.groups-standings-rule {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid rgba(233, 195, 73, 0.25);
+  border-radius: var(--ops-radius);
+  padding: 12px 14px;
+  background: rgba(233, 195, 73, 0.06);
+}
+
+.groups-standings-rule strong {
+  color: var(--ops-secondary);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.groups-standings-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.72fr) minmax(0, 1.28fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.groups-standings-groups,
+.groups-standings-tables,
+.org-groups-board,
+.org-group-team-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.groups-standings-card,
+.groups-standings-table-panel,
+.org-group-card,
+.org-groups-command-card {
+  padding: 16px;
+}
+
+.groups-standings-card-head,
+.groups-standings-table-head,
+.org-group-card-head {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.groups-standings-card h3,
+.groups-standings-table-head h3,
+.org-group-card h3,
+.org-groups-command-card h3 {
+  color: var(--ops-text);
+  font-size: 1rem;
+  text-transform: uppercase;
+}
+
+.groups-standings-card p,
+.groups-standings-muted,
+.org-groups-command-card p,
+.org-groups-state p {
+  color: var(--ops-muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+.groups-standings-team-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.groups-standings-team-chip,
+.groups-standings-empty-chip {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  border: 1px solid var(--ops-line-soft);
+  border-radius: var(--ops-radius-sm);
+  padding: 7px 9px;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--ops-text);
+  font-size: 0.82rem;
+}
+
+.groups-standings-team-chip em {
+  color: var(--ops-secondary);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-style: normal;
+}
+
+.groups-standings-team-chip small {
+  color: var(--ops-cyan);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  text-transform: uppercase;
+}
+
+.groups-standings-empty-chip {
+  color: var(--ops-muted);
+}
+
+.groups-standings-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.groups-standings-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.groups-standings-table th,
+.groups-standings-table td {
+  border-bottom: 1px solid var(--ops-line-soft);
+  padding: 10px 9px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.groups-standings-table th {
+  color: var(--ops-muted-strong);
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.groups-standings-table td {
+  color: var(--ops-text);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.82rem;
+}
+
+.groups-standings-table td strong {
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.9rem;
+}
+
+.groups-standings-state,
+.org-groups-state {
+  display: grid;
+  gap: 8px;
+  border: 1px dashed var(--ops-line);
+  border-radius: var(--ops-radius);
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.groups-standings-state h3,
+.org-groups-state h3 {
+  color: var(--ops-text);
+  text-transform: uppercase;
+}
+
+.groups-standings-management-note {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid var(--ops-line-soft);
+  margin-top: 8px;
+  padding-top: 12px;
+}
+
+.groups-standings-management-note span {
+  color: var(--ops-muted-strong);
+  font-size: 0.88rem;
+}
+
+.groups-standings-state.is-error,
+.org-groups-error {
+  border-color: rgba(255, 84, 78, 0.42);
+  background: rgba(255, 84, 78, 0.08);
+}
+
+.org-groups-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.org-tournament-section-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px;
+}
+
+.org-tournament-section-shortcuts button {
+  border: 1px solid var(--ops-line-soft);
+  border-radius: var(--ops-radius-sm);
+  padding: 8px 11px;
+  background: rgba(255, 255, 255, 0.045);
+  color: var(--ops-muted-strong);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.org-tournament-section-shortcuts button:hover {
+  border-color: var(--ops-cyan);
+  color: var(--ops-cyan);
+}
+
+.org-groups-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 330px);
+  gap: 16px;
+  align-items: start;
+}
+
+.org-groups-main,
+.org-groups-command-rail {
+  display: grid;
+  gap: 14px;
+}
+
+.org-group-team-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--ops-line-soft);
+  border-radius: var(--ops-radius-sm);
+  padding: 10px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.org-group-team-row strong {
+  display: block;
+  color: var(--ops-text);
+}
+
+.org-group-team-row span {
+  color: var(--ops-muted);
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+}
+
+.org-group-team-row button,
+.org-groups-command-card button {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--ops-line);
+  border-radius: var(--ops-radius-sm);
+  padding: 9px 11px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--ops-text);
+  font-weight: 800;
+}
+
+.org-group-team-row button:not(:disabled):hover,
+.org-groups-command-card button:not(:disabled):hover {
+  border-color: var(--ops-primary);
+  color: var(--ops-primary);
+}
+
+.org-group-team-row button:disabled,
+.org-groups-command-card button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.org-groups-command-card {
+  display: grid;
+  gap: 12px;
+}
+
+.org-groups-command-card label {
+  display: grid;
+  gap: 6px;
+}
+
+.org-groups-command-card input,
+.org-groups-command-card select {
+  width: 100%;
+  border: 1px solid var(--ops-line);
+  border-radius: var(--ops-radius-sm);
+  padding: 10px 11px;
+  background: rgba(7, 7, 7, 0.72);
+  color: var(--ops-text);
+}
+
+.org-groups-command-card input:focus,
+.org-groups-command-card select:focus {
+  border-color: var(--ops-cyan);
+  outline: none;
+  box-shadow: var(--ops-glow-cyan);
+}
+
+.org-groups-notice,
+.org-groups-validation,
+.org-groups-error {
+  border-radius: var(--ops-radius-sm);
+  padding: 11px 12px;
+}
+
+.org-groups-notice {
+  border: 1px solid rgba(110, 231, 168, 0.35);
+  background: rgba(110, 231, 168, 0.08);
+  color: var(--ops-green);
+  font-weight: 800;
+}
+
+.org-groups-error {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  color: var(--ops-error);
+}
+
+.org-groups-error strong,
+.org-groups-error span,
+.org-groups-validation span {
+  display: block;
+}
+
+.org-groups-validation {
+  display: grid;
+  gap: 6px;
+  border: 1px solid rgba(233, 195, 73, 0.35);
+  background: rgba(233, 195, 73, 0.08);
+  color: var(--ops-secondary);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1180px) {
+  .groups-standings-summary,
+  .org-groups-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .groups-standings-layout,
+  .org-groups-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .groups-standings-panel,
+  .org-groups-panel {
+    padding: 16px;
+  }
+
+  .groups-standings-summary,
+  .org-groups-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .groups-standings-card-head,
+  .groups-standings-table-head,
+  .org-group-card-head,
+  .org-group-team-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/frontend/src/app/turnirji/[slug]/page.tsx
+++ b/frontend/src/app/turnirji/[slug]/page.tsx
@@ -11,7 +11,9 @@ import {
 
 import { AnalyticsOverview } from "@/components/analytics-overview";
 import { BracketCommandPanel } from "@/components/bracket-command-panel";
+import { GroupsStandingsPanel } from "@/components/groups-standings-panel";
 import { MatchSchedule } from "@/components/match-schedule";
+import { PublicTournamentManageLink } from "@/components/public-tournament-manage-link";
 import { SectionHeader } from "@/components/section-header";
 import { TournamentCommandHeader } from "@/components/tournament-command-header";
 import { TournamentMetaGrid } from "@/components/tournament-meta-grid";
@@ -23,6 +25,10 @@ import {
   getTournamentBySlug,
   getTournaments
 } from "@/lib/data";
+import {
+  getPublicGroupsStandingsData,
+  type PublicGroupsStandingsData
+} from "@/lib/tournament-group-data";
 import { formatDateTime } from "@/lib/utils";
 
 interface TournamentDetailPageProps {
@@ -53,6 +59,20 @@ export default async function TournamentDetailPage({
     notFound();
   }
 
+  let groupsStandings: PublicGroupsStandingsData = {
+    groups: [],
+    standings: []
+  };
+  let groupsStandingsError: string | null = null;
+
+  try {
+    groupsStandings = await getPublicGroupsStandingsData(tournament.id);
+  } catch (error) {
+    groupsStandingsError = error instanceof Error
+      ? error.message
+      : "Group standings are unavailable.";
+  }
+
   const tournamentMatches = matches.filter((match) => match.tournamentSlug === slug);
   const importedMatches = tournamentMatches.filter((match) => match.dotaMatchId).length;
 
@@ -68,9 +88,11 @@ export default async function TournamentDetailPage({
             <Link className="button ops-button-secondary" href="/turnirji">
               All Tournaments
             </Link>
-            <Link className="button ops-button-primary" href="/organizator">
-              Manage
-            </Link>
+            <PublicTournamentManageLink
+              label="Manage Groups"
+              slug={tournament.slug}
+              tournamentId={tournament.id}
+            />
           </>
         }
       >
@@ -109,6 +131,21 @@ export default async function TournamentDetailPage({
       </TournamentCommandHeader>
 
       <TournamentRegistrationPanel tournament={tournament} />
+
+      <GroupsStandingsPanel
+        error={groupsStandingsError}
+        groups={groupsStandings.groups}
+        managementAction={
+          <PublicTournamentManageLink
+            className="button ops-button-secondary"
+            label="Manage Groups"
+            note
+            slug={tournament.slug}
+            tournamentId={tournament.id}
+          />
+        }
+        standings={groupsStandings.standings}
+      />
 
       <section className="tournament-control-grid">
         <div className="tournament-control-main">

--- a/frontend/src/components/groups-standings-panel.tsx
+++ b/frontend/src/components/groups-standings-panel.tsx
@@ -1,0 +1,233 @@
+import { Activity, GitBranch, ListOrdered, ShieldCheck, UsersRound } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { SectionHeader } from "@/components/section-header";
+import type {
+  GroupStanding,
+  PublicTournamentGroup,
+  TournamentGroup
+} from "@/lib/tournament-group-data";
+import { classNames } from "@/lib/utils";
+
+type DisplayGroup = PublicTournamentGroup | TournamentGroup;
+
+interface GroupsStandingsPanelProps {
+  error?: string | null;
+  groups: DisplayGroup[];
+  isLoading?: boolean;
+  managementAction?: ReactNode;
+  mode?: "public" | "organizer";
+  standings: GroupStanding[];
+}
+
+const tieBreakRule = "Points -> Match wins -> Game diff -> Game wins";
+
+function groupId(group: DisplayGroup) {
+  return "groupId" in group ? group.groupId : group.id;
+}
+
+function groupName(group: DisplayGroup) {
+  return "groupName" in group ? group.groupName : group.name;
+}
+
+function groupOrder(group: DisplayGroup) {
+  return "displayOrder" in group ? group.displayOrder : group.sortOrder;
+}
+
+function groupTeams(group: DisplayGroup) {
+  return group.teams;
+}
+
+function teamDisplayName(team: DisplayGroup["teams"][number]) {
+  return "teamName" in team ? team.teamName : team.name;
+}
+
+function teamTag(team: DisplayGroup["teams"][number]) {
+  return "tag" in team ? team.tag : team.teamTag;
+}
+
+function teamSeed(team: DisplayGroup["teams"][number]) {
+  return team.seedNumber;
+}
+
+function standingsByGroup(standings: GroupStanding[]) {
+  return standings.reduce<Record<string, GroupStanding[]>>((accumulator, standing) => {
+    const rows = accumulator[standing.groupId] ?? [];
+    rows.push(standing);
+    accumulator[standing.groupId] = rows;
+    return accumulator;
+  }, {});
+}
+
+function finishedSeries(standings: GroupStanding[]) {
+  const playedSlots = standings.reduce((total, standing) => total + standing.matchesPlayed, 0);
+  return Math.floor(playedSlots / 2);
+}
+
+export function GroupsStandingsPanel({
+  error,
+  groups,
+  isLoading = false,
+  managementAction,
+  mode = "public",
+  standings
+}: GroupsStandingsPanelProps) {
+  const orderedGroups = [...groups].sort((left, right) => groupOrder(left) - groupOrder(right));
+  const tableRows = standingsByGroup(standings);
+  const assignedTeams = orderedGroups.reduce((total, group) => total + groupTeams(group).length, 0);
+  const hasGroups = orderedGroups.length > 0;
+
+  return (
+    <section className={classNames("groups-standings-panel ops-panel", mode === "organizer" && "is-organizer")}>
+      <SectionHeader
+        eyebrow={mode === "organizer" ? "Group stage control" : "Group stage"}
+        title="Groups & Standings"
+        description="Group stage overview based on official match results."
+        action={
+          <span className="ops-badge">
+            <ShieldCheck size={14} />
+            Backend calculated
+          </span>
+        }
+      />
+
+      <div className="groups-standings-summary">
+        <SummaryMetric icon={GitBranch} label="Groups" value={String(orderedGroups.length)} />
+        <SummaryMetric icon={UsersRound} label="Assigned Teams" value={String(assignedTeams)} />
+        <SummaryMetric icon={Activity} label="Finished Series" value={String(finishedSeries(standings))} />
+        <SummaryMetric icon={ListOrdered} label="Points Rule" value="3/1/0" />
+      </div>
+
+      <div className="groups-standings-rule">
+        <span>Tie-break rule</span>
+        <strong>{tieBreakRule}</strong>
+      </div>
+
+      {isLoading ? (
+        <div className="groups-standings-state">
+          <h3>Loading groups and standings...</h3>
+          <p>Connecting to the official tournament group API.</p>
+        </div>
+      ) : error ? (
+        <div className="groups-standings-state is-error">
+          <h3>Group standings are unavailable.</h3>
+          <p>{error}</p>
+        </div>
+      ) : !hasGroups ? (
+        <div className="groups-standings-state">
+          <h3>Groups are not published yet.</h3>
+          <p>Official standings will appear here once tournament groups are available.</p>
+          {managementAction}
+        </div>
+      ) : (
+        <div className="groups-standings-layout">
+          <div className="groups-standings-groups">
+            {orderedGroups.map((group) => {
+              const teams = groupTeams(group);
+              const rows = tableRows[groupId(group)] ?? [];
+
+              return (
+                <article className="groups-standings-card ops-card" key={groupId(group)}>
+                  <div className="groups-standings-card-head">
+                    <div>
+                      <span className="ops-label">Group {groupOrder(group) || "-"}</span>
+                      <h3>{groupName(group)}</h3>
+                    </div>
+                    <span className="ops-badge">{rows.length > 0 ? "Active" : "Setup"}</span>
+                  </div>
+                  <div className="groups-standings-team-list">
+                    {teams.length === 0 ? (
+                      <span className="groups-standings-empty-chip">No teams assigned</span>
+                    ) : (
+                      teams.map((team) => (
+                        <span className="groups-standings-team-chip" key={"teamId" in team ? team.teamId : team.id}>
+                          {teamSeed(team) ? <em>#{teamSeed(team)}</em> : null}
+                          <strong>{teamDisplayName(team)}</strong>
+                          {teamTag(team) ? <small>{teamTag(team)}</small> : null}
+                        </span>
+                      ))
+                    )}
+                  </div>
+                  <p>{teams.length} teams assigned</p>
+                </article>
+              );
+            })}
+          </div>
+
+          <div className="groups-standings-tables">
+            {orderedGroups.map((group) => {
+              const rows = [...(tableRows[groupId(group)] ?? [])].sort((left, right) => left.rank - right.rank);
+
+              return (
+                <article className="groups-standings-table-panel ops-card" key={`${groupId(group)}-standings`}>
+                  <div className="groups-standings-table-head">
+                    <div>
+                      <span className="ops-label">Standings</span>
+                      <h3>{groupName(group)}</h3>
+                    </div>
+                    <span className="ops-badge">{rows.length} rows</span>
+                  </div>
+                  {rows.length === 0 ? (
+                    <p className="groups-standings-muted">No official standings rows are available for this group yet.</p>
+                  ) : (
+                    <div className="groups-standings-table-wrap">
+                      <table className="groups-standings-table">
+                        <thead>
+                          <tr>
+                            <th>Rank</th>
+                            <th>Team</th>
+                            <th>Played</th>
+                            <th>W-L-D</th>
+                            <th>Games</th>
+                            <th>Diff</th>
+                            <th>Points</th>
+                            <th>Tie-break</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {rows.map((standing) => (
+                            <tr key={standing.teamId}>
+                              <td>#{standing.rank}</td>
+                              <td>
+                                <strong>{standing.teamName}</strong>
+                              </td>
+                              <td>{standing.matchesPlayed}</td>
+                              <td>{standing.matchWins}-{standing.matchLosses}-{standing.matchDraws}</td>
+                              <td>{standing.gameWins}-{standing.gameLosses}</td>
+                              <td>{standing.gameDiff > 0 ? `+${standing.gameDiff}` : standing.gameDiff}</td>
+                              <td>{standing.points}</td>
+                              <td>Rule order</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SummaryMetric({
+  icon: Icon,
+  label,
+  value
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+}) {
+  return (
+    <article className="groups-standings-summary-card ops-card">
+      <Icon size={18} />
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}

--- a/frontend/src/components/organizer-command-page.tsx
+++ b/frontend/src/components/organizer-command-page.tsx
@@ -31,6 +31,7 @@ import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
+import { OrganizerGroupManagementPanel } from "@/components/organizer-group-management-panel";
 import { ApiRequestError, type ApiFieldError } from "@/lib/api";
 import { getCurrentUserProfile, type CurrentUserProfile, type ProfileRole } from "@/lib/auth";
 import {
@@ -311,6 +312,18 @@ function canAccessOrganizer(role?: ProfileRole | null) {
   return role === "organizer" || role === "admin";
 }
 
+function sectionIdForInitialView(view?: string) {
+  if (view === "registrations") {
+    return "registration-review";
+  }
+
+  if (view === "groups") {
+    return "group-management";
+  }
+
+  return null;
+}
+
 export function OrganizerCommandPage({
   initialSlug,
   initialTournamentId,
@@ -405,7 +418,7 @@ export function OrganizerCommandPage({
       setTournaments(nextTournaments);
       setLoadState("ready");
 
-      if (initialView === "registrations" && (initialTournamentId || initialSlug)) {
+      if (sectionIdForInitialView(initialView) && (initialTournamentId || initialSlug)) {
         const matchedTournament = nextTournaments.find(
           (tournament) =>
             (initialTournamentId && tournament.id === initialTournamentId) ||
@@ -477,6 +490,23 @@ export function OrganizerCommandPage({
 
     return () => window.clearTimeout(timeout);
   }, [loadOrganizerAccess]);
+
+  useEffect(() => {
+    const targetId = sectionIdForInitialView(initialView);
+
+    if (view !== "detail" || !selectedTournament || !targetId) {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      document.getElementById(targetId)?.scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      });
+    }, 180);
+
+    return () => window.clearTimeout(timeout);
+  }, [initialView, selectedTournament, view]);
 
   const counts = useMemo(() => dashboardCounts(tournaments), [tournaments]);
 
@@ -1006,6 +1036,13 @@ function TournamentDetail({
     [filter, registrations]
   );
 
+  function scrollToSection(sectionId: string) {
+    document.getElementById(sectionId)?.scrollIntoView({
+      behavior: "smooth",
+      block: "start"
+    });
+  }
+
   return (
     <>
       <section className="org-tournament-detail-hero ops-panel">
@@ -1035,6 +1072,13 @@ function TournamentDetail({
           </div>
         ))}
       </section>
+
+      <nav className="org-tournament-section-shortcuts ops-panel" aria-label="Tournament detail sections">
+        <button onClick={() => scrollToSection("registration-review")} type="button">Registrations</button>
+        <button onClick={() => scrollToSection("group-management")} type="button">Groups</button>
+        <button onClick={() => scrollToSection("staff-officials")} type="button">Staff</button>
+        <button onClick={() => scrollToSection("match-operations-flow")} type="button">Match Controls</button>
+      </nav>
 
       <section className="org-tournament-detail-grid">
         <main className="org-tournament-detail-main">
@@ -1115,6 +1159,12 @@ function TournamentDetail({
               </div>
             )}
           </section>
+
+          <OrganizerGroupManagementPanel
+            matches={matches}
+            registrations={registrations}
+            tournament={tournament}
+          />
 
           <StaffOfficialsPanel
             currentProfile={currentProfile}
@@ -1207,10 +1257,10 @@ function staffRowsForTournament(
     "Tournament owner / organizer";
 
   rows.push({
-    actions: "Locked until staff API is available",
+    actions: "Locked in current role model",
     id: tournament.organizerProfileId ?? "tournament-owner",
     name: ownerName,
-    permissions: ["Manage registrations", "Schedule matches", "Enter results", "View only"],
+    permissions: ["Manage registrations", "Schedule matches", "Enter results"],
     role: "Owner",
     scope: "Tournament-wide",
     status: "Active",
@@ -1227,7 +1277,7 @@ function staffRowsForTournament(
       name: currentProfile.nickname,
       permissions: currentProfile.role === "admin"
         ? ["Manage registrations", "Schedule matches", "Enter results", "View only"]
-        : ["View only"],
+        : ["Organizer workspace"],
       role: "Organizer",
       scope: currentProfile.role === "admin" ? "Admin override" : "Current session",
       status: "Active session",
@@ -1252,23 +1302,22 @@ function StaffOfficialsPanel({
   const staffRows = staffRowsForTournament(tournament, currentProfile);
   const organizers = staffRows.filter((row) => row.role === "Owner" || row.role === "Organizer").length;
   const summary = [
-    { label: "Total Staff", tone: "red", value: staffRows.length },
-    { label: "Organizers", tone: "cyan", value: organizers },
-    { label: "Match Officials", tone: "gold", value: 0 },
-    { label: "Observers", tone: "green", value: 0 },
-    { label: "Pending Invites", tone: "muted", value: 0 }
+    { label: "Operators", tone: "red", value: staffRows.length },
+    { label: "Organizer Controls", tone: "cyan", value: organizers },
+    { label: "Backend Staff API", tone: "gold", value: 0 },
+    { label: "Locked Actions", tone: "muted", value: 5 }
   ];
 
   return (
     <section className="org-tournament-panel org-staff-panel ops-panel" id="staff-officials">
       <div className="org-tournament-panel-title">
         <div>
-          <p className="ops-label">Organizer Staff Controls</p>
-          <h2>Tournament Operations Staff</h2>
+          <p className="ops-label">Organizer Operations</p>
+          <h2>Organizer Operations Staff</h2>
           <p>
-            Organizers can prepare tournament-scoped staff roles here. Dedicated
-            staff or match official account flows are not enabled until backend
-            permissions are available.
+            Organizer/admin currently controls tournament operations. Separate
+            referee, analyst, or score reporter account roles are not enabled in
+            this project scope.
           </p>
         </div>
         <span className="ops-badge">
@@ -1291,10 +1340,10 @@ function StaffOfficialsPanel({
           <table className="org-staff-table">
             <thead>
               <tr>
-                <th>Staff member</th>
-                <th>Primary role</th>
+                <th>Operator</th>
+                <th>Workspace role</th>
                 <th>Scope</th>
-                <th>Permissions</th>
+                <th>Organizer controls</th>
                 <th>Status</th>
                 <th>Actions</th>
               </tr>
@@ -1340,7 +1389,7 @@ function StaffOfficialsPanel({
         <aside className="org-staff-command-rail">
           <button disabled type="button">
             <Plus size={16} />
-            Add Official
+            Add Staff
             <Lock size={14} />
           </button>
           <button disabled type="button">
@@ -1371,8 +1420,8 @@ function StaffOfficialsPanel({
       </div>
 
       <PanelWarning
-        title="Organizer-controlled staff API required"
-        detail="Backend staff endpoints are required before organizers can add officials, change tournament-scoped roles, or remove staff. These are not separate login roles."
+        title="Organizer/admin controlled"
+        detail="Dedicated staff management is not part of the current role model. Organizer/admin handles these operations, and disabled controls need backend staff endpoints before they can be enabled."
       />
     </section>
   );
@@ -1390,21 +1439,21 @@ type PermissionState = "allowed" | "restricted" | "backend" | "unavailable";
 
 interface PermissionRow {
   action: string;
-  matchOfficial: PermissionState;
+  backendRequired: PermissionState;
+  currentSupport: PermissionState;
+  note: string;
   organizer: PermissionState;
-  observer: PermissionState;
-  reporter: PermissionState;
 }
 
 const permissionRows: PermissionRow[] = [
-  { action: "Schedule match", matchOfficial: "backend", observer: "unavailable", organizer: "allowed", reporter: "unavailable" },
-  { action: "Start match", matchOfficial: "backend", observer: "unavailable", organizer: "allowed", reporter: "unavailable" },
-  { action: "Enter result", matchOfficial: "backend", observer: "unavailable", organizer: "allowed", reporter: "backend" },
-  { action: "Confirm result", matchOfficial: "backend", observer: "unavailable", organizer: "backend", reporter: "restricted" },
-  { action: "Finish match", matchOfficial: "backend", observer: "unavailable", organizer: "allowed", reporter: "unavailable" },
-  { action: "Cancel match", matchOfficial: "backend", observer: "unavailable", organizer: "allowed", reporter: "unavailable" },
-  { action: "Handle dispute", matchOfficial: "backend", observer: "unavailable", organizer: "unavailable", reporter: "restricted" },
-  { action: "Import match data", matchOfficial: "backend", observer: "restricted", organizer: "allowed", reporter: "unavailable" }
+  { action: "Schedule match", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer endpoint exists.", organizer: "allowed" },
+  { action: "Start match", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer endpoint exists.", organizer: "allowed" },
+  { action: "Enter result", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer result endpoint exists.", organizer: "allowed" },
+  { action: "Confirm result", backendRequired: "backend", currentSupport: "backend", note: "Approval workflow is not active.", organizer: "backend" },
+  { action: "Finish match", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer endpoint exists.", organizer: "allowed" },
+  { action: "Cancel match", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer endpoint exists.", organizer: "allowed" },
+  { action: "Handle dispute", backendRequired: "backend", currentSupport: "unavailable", note: "Dispute process is outside current scope.", organizer: "unavailable" },
+  { action: "Import match data", backendRequired: "unavailable", currentSupport: "allowed", note: "Organizer import flow exists where enabled.", organizer: "allowed" }
 ];
 
 function MatchOperationsControlPanel({
@@ -1430,11 +1479,10 @@ function MatchOperationsControlPanel({
       <div className="org-tournament-panel-title">
         <div>
           <p className="ops-label">Organizer Match Control Flow</p>
-          <h2>Match Operations & Official Limits</h2>
+          <h2>Organizer Match Operations</h2>
           <p>
-            Organizer-supported match control with planned tournament official
-            scopes shown as backend-required limitations, not separate account
-            workflows.
+            Only organizer/admin has access to this workspace. Referee or
+            analyst-specific accounts are not used in the current implementation.
           </p>
         </div>
         <span className="ops-badge">
@@ -1483,9 +1531,9 @@ function MatchOperationsControlPanel({
                 <tr>
                   <th>Process</th>
                   <th>Organizer/Admin</th>
-                  <th>Match Official</th>
-                  <th>Score Reporter</th>
-                  <th>Analyst/Observer</th>
+                  <th>Current Support</th>
+                  <th>Backend Required</th>
+                  <th>Notes</th>
                 </tr>
               </thead>
               <tbody>
@@ -1493,9 +1541,9 @@ function MatchOperationsControlPanel({
                   <tr key={row.action}>
                     <td>{row.action}</td>
                     <td><PermissionStateBadge state={row.organizer} /></td>
-                    <td><PermissionStateBadge state={row.matchOfficial} /></td>
-                    <td><PermissionStateBadge state={row.reporter} /></td>
-                    <td><PermissionStateBadge state={row.observer} /></td>
+                    <td><PermissionStateBadge state={row.currentSupport} /></td>
+                    <td><PermissionStateBadge state={row.backendRequired} /></td>
+                    <td>{row.note}</td>
                   </tr>
                 ))}
               </tbody>
@@ -1504,16 +1552,16 @@ function MatchOperationsControlPanel({
 
           <div className="org-referee-limitations">
             <article>
-              <strong>Planned match official scope</strong>
-              <p>Future match official scope can only act on assigned matches once organizer-controlled backend permissions exist.</p>
+              <strong>Organizer/admin workspace</strong>
+              <p>All active tournament operations are controlled by organizer/admin accounts.</p>
             </article>
             <article>
-              <strong>Planned score reporter scope</strong>
-              <p>Score reporter actions are planned as tournament-scoped operations. They are not active as separate account flows.</p>
+              <strong>No separate official login</strong>
+              <p>Referee, analyst, and score reporter account flows are not part of the current project scope.</p>
             </article>
             <article>
-              <strong>Organizer-controlled operations</strong>
-              <p>Organizer/admin has the current override only where existing backend match endpoints support it.</p>
+              <strong>Backend-gated controls</strong>
+              <p>Unsupported operations stay locked until organizer-focused backend endpoints exist.</p>
             </article>
           </div>
         </div>
@@ -1521,7 +1569,7 @@ function MatchOperationsControlPanel({
         <aside className="org-referee-command-panel">
           <button disabled type="button">
             <Plus size={16} />
-            Assign Match Official
+            Assign Operator
             <Lock size={14} />
           </button>
           <button disabled type="button">
@@ -1546,7 +1594,7 @@ function MatchOperationsControlPanel({
 
           <PanelWarning
             title="Backend status"
-            detail="Official assignment and score reporter approval are planned as organizer-controlled functionality. Separate referee or analyst login flows are not enabled."
+            detail="Dedicated official assignment is not part of the current role model. Organizer/admin remains responsible for match operations."
           />
         </aside>
       </div>

--- a/frontend/src/components/organizer-group-management-panel.tsx
+++ b/frontend/src/components/organizer-group-management-panel.tsx
@@ -1,0 +1,419 @@
+"use client";
+
+import { AlertTriangle, GitBranch, ListOrdered, Plus, RefreshCw, ShieldCheck, Trash2, UsersRound } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+import { GroupsStandingsPanel } from "@/components/groups-standings-panel";
+import { ApiRequestError, type ApiFieldError } from "@/lib/api";
+import type { OrganizerMatch } from "@/lib/organizer-match-data";
+import type { OrganizerTournament } from "@/lib/organizer-tournament-data";
+import {
+  addTeamToOrganizerGroup,
+  createOrganizerTournamentGroup,
+  getOrganizerGroupsData,
+  removeTeamFromOrganizerGroup,
+  type OrganizerGroupsData,
+  type TournamentGroup
+} from "@/lib/tournament-group-data";
+import type { TournamentRegistration } from "@/lib/tournament-registration-data";
+import { classNames } from "@/lib/utils";
+
+interface OrganizerGroupManagementPanelProps {
+  matches: OrganizerMatch[];
+  registrations: TournamentRegistration[];
+  tournament: OrganizerTournament;
+}
+
+interface PanelErrorState {
+  errors: ApiFieldError[];
+  message: string;
+  status: number | null;
+}
+
+function panelError(error: unknown, fallback: string): PanelErrorState {
+  if (error instanceof ApiRequestError) {
+    return {
+      errors: error.errors,
+      message: error.message || fallback,
+      status: error.status
+    };
+  }
+
+  return {
+    errors: [],
+    message: error instanceof Error ? error.message : fallback,
+    status: null
+  };
+}
+
+function optionalNumber(value: string) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function standingsStatus(data: OrganizerGroupsData | null) {
+  if (!data) {
+    return "Loading";
+  }
+
+  if (data.standingsError) {
+    return "Private/TODO";
+  }
+
+  return data.standings.length > 0 ? "Synced" : "Empty";
+}
+
+export function OrganizerGroupManagementPanel({
+  matches,
+  registrations,
+  tournament
+}: OrganizerGroupManagementPanelProps) {
+  const [data, setData] = useState<OrganizerGroupsData | null>(null);
+  const [error, setError] = useState<PanelErrorState | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<ApiFieldError[]>([]);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isMutating, setIsMutating] = useState(false);
+  const [groupName, setGroupName] = useState("");
+  const [groupOrder, setGroupOrder] = useState("");
+  const [selectedGroupId, setSelectedGroupId] = useState("");
+  const [selectedTeamId, setSelectedTeamId] = useState("");
+  const [seedNumber, setSeedNumber] = useState("");
+
+  const loadGroups = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setFieldErrors([]);
+
+    try {
+      const nextData = await getOrganizerGroupsData(tournament.id);
+      setData(nextData);
+
+      setSelectedGroupId((currentGroupId) => currentGroupId || nextData.groups[0]?.id || "");
+    } catch (loadError) {
+      setData(null);
+      setError(panelError(loadError, "Group management API is unavailable."));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tournament.id]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => void loadGroups(), 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [loadGroups]);
+
+  const assignedTeamIds = useMemo(() => {
+    const ids = new Set<string>();
+    data?.groups.forEach((group) => {
+      group.teams.forEach((team) => ids.add(team.teamId));
+    });
+    return ids;
+  }, [data?.groups]);
+
+  const approvedUnassignedRegistrations = useMemo(
+    () => registrations.filter((registration) =>
+      registration.status === "approved" && !assignedTeamIds.has(registration.teamId)
+    ),
+    [assignedTeamIds, registrations]
+  );
+
+  const effectiveSelectedTeamId = approvedUnassignedRegistrations.some(
+    (registration) => registration.teamId === selectedTeamId
+  )
+    ? selectedTeamId
+    : approvedUnassignedRegistrations[0]?.teamId ?? "";
+
+  const assignedTeams = data?.groups.reduce((total, group) => total + group.teams.length, 0) ?? 0;
+  const finishedMatches = matches.filter((match) => match.status === "finished").length;
+
+  async function createGroup(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsMutating(true);
+    setError(null);
+    setFieldErrors([]);
+    setNotice(null);
+
+    try {
+      await createOrganizerTournamentGroup(tournament.id, {
+        name: groupName,
+        sortOrder: optionalNumber(groupOrder)
+      });
+      setGroupName("");
+      setGroupOrder("");
+      setNotice("Group created from backend API.");
+      await loadGroups();
+    } catch (createError) {
+      const nextError = panelError(createError, "Group could not be created.");
+      setError(nextError);
+      setFieldErrors(nextError.errors);
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
+  async function addTeam(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!selectedGroupId || !effectiveSelectedTeamId) {
+      setError({
+        errors: [],
+        message: "Select a group and an approved unassigned team before adding a team.",
+        status: null
+      });
+      return;
+    }
+
+    setIsMutating(true);
+    setError(null);
+    setFieldErrors([]);
+    setNotice(null);
+
+    try {
+      await addTeamToOrganizerGroup(selectedGroupId, {
+        seedNumber: optionalNumber(seedNumber),
+        teamId: effectiveSelectedTeamId
+      });
+      setSeedNumber("");
+      setNotice("Team assignment saved through backend API.");
+      await loadGroups();
+    } catch (addError) {
+      const nextError = panelError(addError, "Team could not be added to the selected group.");
+      setError(nextError);
+      setFieldErrors(nextError.errors);
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
+  async function removeTeam(group: TournamentGroup, teamId: string) {
+    setIsMutating(true);
+    setError(null);
+    setFieldErrors([]);
+    setNotice(null);
+
+    try {
+      await removeTeamFromOrganizerGroup(group.id, teamId);
+      setNotice("Team removed from group through backend API.");
+      await loadGroups();
+    } catch (removeError) {
+      const nextError = panelError(removeError, "Team could not be removed from this group.");
+      setError(nextError);
+      setFieldErrors(nextError.errors);
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
+  return (
+    <section className="org-tournament-panel org-groups-panel ops-panel" id="group-management">
+      <div className="org-tournament-panel-title">
+        <div>
+          <p className="ops-label">Group Management / Standings Control</p>
+          <h2>Group Management</h2>
+          <span>Assign approved teams to groups and monitor backend-calculated standings.</span>
+        </div>
+        <button className="org-tournament-secondary" disabled={isLoading || isMutating} onClick={loadGroups} type="button">
+          <RefreshCw size={15} />
+          Refresh Groups
+        </button>
+      </div>
+
+      <div className="org-groups-summary">
+        <SummaryCard icon={GitBranch} label="Groups" value={String(data?.groups.length ?? 0)} tone="red" />
+        <SummaryCard icon={UsersRound} label="Assigned Teams" value={String(assignedTeams)} tone="cyan" />
+        <SummaryCard icon={ShieldCheck} label="Approved Unassigned Teams" value={String(approvedUnassignedRegistrations.length)} tone="gold" />
+        <SummaryCard icon={ListOrdered} label="Finished Matches" value={String(finishedMatches)} tone="green" />
+        <SummaryCard icon={ShieldCheck} label="Standings Status" value={standingsStatus(data)} tone={data?.standingsError ? "red" : "cyan"} />
+      </div>
+
+      {notice ? <p className="org-groups-notice">{notice}</p> : null}
+      {error ? <GroupPanelError error={error} /> : null}
+      {fieldErrors.length > 0 ? (
+        <div className="org-groups-validation">
+          {fieldErrors.map((fieldError, index) => (
+            <span key={`${fieldError.field ?? "field"}-${index}`}>
+              {fieldError.field ? `${fieldError.field}: ` : null}
+              {fieldError.message ?? "Validation error"}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="org-groups-layout">
+        <div className="org-groups-main">
+          {isLoading ? (
+            <div className="org-groups-state">
+              <h3>Loading group assignments...</h3>
+              <p>Connecting to organizer group endpoints.</p>
+            </div>
+          ) : !data || data.groups.length === 0 ? (
+            <div className="org-groups-state">
+              <h3>No groups configured yet.</h3>
+              <p>Create the first group when approved teams are ready for group-stage assignment.</p>
+            </div>
+          ) : (
+            <div className="org-groups-board">
+              {data.groups.map((group) => (
+                <article className="org-group-card ops-card" key={group.id}>
+                  <div className="org-group-card-head">
+                    <div>
+                      <span className="ops-label">Group {group.sortOrder || "-"}</span>
+                      <h3>{group.name}</h3>
+                    </div>
+                    <span className="ops-badge">{group.teams.length} teams</span>
+                  </div>
+                  <div className="org-group-team-stack">
+                    {group.teams.length === 0 ? (
+                      <p className="org-tournament-muted">No approved teams assigned.</p>
+                    ) : (
+                      group.teams.map((team) => (
+                        <div className="org-group-team-row" key={team.teamId}>
+                          <div>
+                            <strong>{team.teamName}</strong>
+                            <span>
+                              {team.seedNumber ? `Seed #${team.seedNumber}` : "No seed"} / {team.teamTag ?? team.teamSlug ?? "No tag"}
+                            </span>
+                          </div>
+                          <button disabled={isMutating} onClick={() => void removeTeam(group, team.teamId)} type="button">
+                            <Trash2 size={14} />
+                            Remove
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+
+          <GroupsStandingsPanel
+            error={data?.standingsError ?? null}
+            groups={data?.groups ?? []}
+            isLoading={isLoading}
+            mode="organizer"
+            standings={data?.standings ?? []}
+          />
+        </div>
+
+        <aside className="org-groups-command-rail">
+          <form className="org-groups-command-card ops-card" onSubmit={createGroup}>
+            <div>
+              <p className="ops-label">Create Group</p>
+              <h3>New Group</h3>
+            </div>
+            <label>
+              <span>Group Name</span>
+              <input disabled={isMutating} onChange={(event) => setGroupName(event.target.value)} placeholder="Group A" value={groupName} />
+            </label>
+            <label>
+              <span>Sort Order</span>
+              <input disabled={isMutating} min={1} onChange={(event) => setGroupOrder(event.target.value)} placeholder="1" type="number" value={groupOrder} />
+            </label>
+            <button className="org-tournament-primary" disabled={isMutating || !groupName.trim()} type="submit">
+              <Plus size={15} />
+              Create Group
+            </button>
+          </form>
+
+          <form className="org-groups-command-card ops-card" onSubmit={addTeam}>
+            <div>
+              <p className="ops-label">Add Team</p>
+              <h3>Approved Assignment</h3>
+            </div>
+            <label>
+              <span>Target Group</span>
+              <select disabled={isMutating || !data?.groups.length} onChange={(event) => setSelectedGroupId(event.target.value)} value={selectedGroupId}>
+                {(data?.groups ?? []).map((group) => (
+                  <option key={group.id} value={group.id}>{group.name}</option>
+                ))}
+              </select>
+            </label>
+            <label>
+              <span>Approved Team</span>
+              <select disabled={isMutating || approvedUnassignedRegistrations.length === 0} onChange={(event) => setSelectedTeamId(event.target.value)} value={effectiveSelectedTeamId}>
+                {approvedUnassignedRegistrations.length === 0 ? (
+                  <option value="">No approved unassigned teams available</option>
+                ) : (
+                  approvedUnassignedRegistrations.map((registration) => (
+                    <option key={registration.teamId} value={registration.teamId}>
+                      {registration.teamName}
+                    </option>
+                  ))
+                )}
+              </select>
+            </label>
+            <label>
+              <span>Seed Number</span>
+              <input disabled={isMutating} min={1} onChange={(event) => setSeedNumber(event.target.value)} placeholder="Optional" type="number" value={seedNumber} />
+            </label>
+            <button className="org-tournament-primary" disabled={isMutating || !selectedGroupId || !effectiveSelectedTeamId} type="submit">
+              Add Team
+            </button>
+          </form>
+
+          <div className="org-groups-command-card ops-card">
+            <div>
+              <p className="ops-label">Unsupported Commands</p>
+              <h3>Backend Required</h3>
+            </div>
+            <button disabled type="button">Auto-generate groups unavailable</button>
+            <button disabled type="button">Bulk seed teams unavailable</button>
+            <button disabled type="button">Recalculate standings unavailable</button>
+            <button disabled type="button">Manual tie-break override unavailable</button>
+            <button disabled type="button">Export standings unavailable</button>
+            <button disabled type="button">Advanced tie-break editor unavailable</button>
+            <p>Standings are read-only and calculated by backend results.</p>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function SummaryCard({
+  icon: Icon,
+  label,
+  tone,
+  value
+}: {
+  icon: LucideIcon;
+  label: string;
+  tone: "cyan" | "gold" | "green" | "red";
+  value: string;
+}) {
+  return (
+    <article className={classNames("org-groups-summary-card ops-card", `is-${tone}`)}>
+      <Icon size={18} />
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </article>
+  );
+}
+
+function GroupPanelError({ error }: { error: PanelErrorState }) {
+  const title = error.status === 403
+    ? "Permission denied"
+    : error.status === 404
+      ? "Group data not found"
+      : "Group operation failed";
+
+  return (
+    <div className="org-groups-error">
+      <AlertTriangle size={17} />
+      <div>
+        <strong>{title}</strong>
+        <span>{error.message}</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/public-tournament-manage-link.tsx
+++ b/frontend/src/components/public-tournament-manage-link.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Settings } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getCurrentUserProfile } from "@/lib/auth";
+import { listOrganizerTournaments } from "@/lib/organizer-tournament-data";
+import { isOrganizerRole } from "@/lib/route-access";
+
+interface PublicTournamentManageLinkProps {
+  className?: string;
+  label?: string;
+  note?: boolean;
+  slug: string;
+  tournamentId: string;
+}
+
+export function PublicTournamentManageLink({
+  className = "button ops-button-primary",
+  label = "Manage Groups",
+  note = false,
+  slug,
+  tournamentId
+}: PublicTournamentManageLinkProps) {
+  const [href, setHref] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function resolveManageLink() {
+      try {
+        const profile = await getCurrentUserProfile();
+
+        if (!isMounted || !isOrganizerRole(profile?.role)) {
+          return;
+        }
+
+        const tournaments = await listOrganizerTournaments();
+        const manageableTournament = tournaments.find(
+          (tournament) => tournament.id === tournamentId || tournament.slug === slug
+        );
+
+        if (isMounted && manageableTournament) {
+          setHref(
+            `/organizator?tournamentId=${encodeURIComponent(manageableTournament.id)}&slug=${encodeURIComponent(manageableTournament.slug)}&view=groups#group-management`
+          );
+        }
+      } catch {
+        if (isMounted) {
+          setHref(null);
+        }
+      }
+    }
+
+    const timeout = window.setTimeout(() => void resolveManageLink(), 0);
+
+    return () => {
+      isMounted = false;
+      window.clearTimeout(timeout);
+    };
+  }, [slug, tournamentId]);
+
+  if (!href) {
+    return null;
+  }
+
+  if (note) {
+    return (
+      <div className="groups-standings-management-note">
+        <span>Group management is available in Organizer workspace.</span>
+        <Link className={className} href={href}>
+          <Settings size={16} />
+          <span>{label}</span>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <Link className={className} href={href}>
+      <Settings size={16} />
+      <span>{label}</span>
+    </Link>
+  );
+}

--- a/frontend/src/lib/tournament-group-data.ts
+++ b/frontend/src/lib/tournament-group-data.ts
@@ -1,0 +1,325 @@
+import {
+  deleteApiAuthenticated,
+  getApi,
+  getApiAuthenticated,
+  postApiAuthenticated
+} from "@/lib/api";
+
+export interface PublicTournamentTeam {
+  id: string;
+  logoUrl: string | null;
+  name: string;
+  seedNumber: number | null;
+  slug: string | null;
+  tag: string | null;
+}
+
+export interface PublicTournamentGroup {
+  displayOrder: number;
+  groupId: string;
+  groupName: string;
+  teams: PublicTournamentTeam[];
+  tournamentId: string;
+}
+
+export interface TournamentGroup {
+  createdAt: string | null;
+  id: string;
+  name: string;
+  sortOrder: number;
+  teams: TournamentGroupTeam[];
+  tournamentId: string;
+  updatedAt: string | null;
+}
+
+export interface TournamentGroupTeam {
+  createdAt: string | null;
+  groupId: string;
+  id: string;
+  registrationId: string | null;
+  seedNumber: number | null;
+  teamId: string;
+  teamName: string;
+  teamSlug: string | null;
+  teamTag: string | null;
+  tournamentId: string;
+  updatedAt: string | null;
+}
+
+export interface GroupStanding {
+  gameDiff: number;
+  gameLosses: number;
+  gameWins: number;
+  groupId: string;
+  groupName: string | null;
+  matchDraws: number;
+  matchLosses: number;
+  matchWins: number;
+  matchesPlayed: number;
+  points: number;
+  rank: number;
+  teamId: string;
+  teamName: string;
+  tournamentId: string;
+}
+
+export interface PublicGroupsStandingsData {
+  groups: PublicTournamentGroup[];
+  standings: GroupStanding[];
+}
+
+export interface OrganizerGroupsData {
+  groups: TournamentGroup[];
+  standings: GroupStanding[];
+  standingsError: string | null;
+}
+
+export interface CreateTournamentGroupInput {
+  name: string;
+  sortOrder?: number | null;
+}
+
+export interface AddTeamToGroupInput {
+  seedNumber?: number | null;
+  teamId: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function arrayPayload(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (isRecord(value) && Array.isArray(value.content)) {
+    return value.content;
+  }
+
+  if (isRecord(value) && Array.isArray(value.items)) {
+    return value.items;
+  }
+
+  return [];
+}
+
+function text(value: unknown, fallback = "") {
+  return typeof value === "string" ? value : fallback;
+}
+
+function nullableText(value: unknown) {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown, fallback = 0) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function nullableNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function mapPublicTeam(value: unknown): PublicTournamentTeam {
+  if (!isRecord(value)) {
+    return {
+      id: "unknown-team",
+      logoUrl: null,
+      name: "Unknown team",
+      seedNumber: null,
+      slug: null,
+      tag: null
+    };
+  }
+
+  return {
+    id: text(value.id, "unknown-team"),
+    logoUrl: nullableText(value.logoUrl),
+    name: text(value.name, "Unknown team"),
+    seedNumber: nullableNumber(value.seedNumber),
+    slug: nullableText(value.slug),
+    tag: nullableText(value.tag)
+  };
+}
+
+function mapPublicGroup(value: unknown): PublicTournamentGroup {
+  if (!isRecord(value)) {
+    throw new Error("Public tournament group API returned an unexpected group shape.");
+  }
+
+  return {
+    displayOrder: numberValue(value.displayOrder ?? value.sortOrder, 0),
+    groupId: text(value.groupId ?? value.id),
+    groupName: text(value.groupName ?? value.name, "Unnamed group"),
+    teams: arrayPayload(value.teams).map(mapPublicTeam),
+    tournamentId: text(value.tournamentId)
+  };
+}
+
+function mapOrganizerGroup(value: unknown, teams: TournamentGroupTeam[] = []): TournamentGroup {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    throw new Error("Organizer tournament group API returned an unexpected group shape.");
+  }
+
+  return {
+    createdAt: nullableText(value.createdAt),
+    id: value.id,
+    name: text(value.name, "Unnamed group"),
+    sortOrder: numberValue(value.sortOrder, 0),
+    teams,
+    tournamentId: text(value.tournamentId),
+    updatedAt: nullableText(value.updatedAt)
+  };
+}
+
+function mapOrganizerGroupTeam(value: unknown): TournamentGroupTeam {
+  if (!isRecord(value) || typeof value.id !== "string" || typeof value.teamId !== "string") {
+    throw new Error("Organizer group team API returned an unexpected team assignment shape.");
+  }
+
+  return {
+    createdAt: nullableText(value.createdAt),
+    groupId: text(value.groupId),
+    id: value.id,
+    registrationId: nullableText(value.registrationId),
+    seedNumber: nullableNumber(value.seedNumber),
+    teamId: value.teamId,
+    teamName: text(value.teamName, "Unknown team"),
+    teamSlug: nullableText(value.teamSlug),
+    teamTag: nullableText(value.teamTag),
+    tournamentId: text(value.tournamentId),
+    updatedAt: nullableText(value.updatedAt)
+  };
+}
+
+function mapStanding(value: unknown): GroupStanding {
+  if (!isRecord(value) || typeof value.teamId !== "string") {
+    throw new Error("Group standings API returned an unexpected standing shape.");
+  }
+
+  return {
+    gameDiff: numberValue(value.gameDiff),
+    gameLosses: numberValue(value.gameLosses),
+    gameWins: numberValue(value.gameWins),
+    groupId: text(value.groupId),
+    groupName: nullableText(value.groupName),
+    matchDraws: numberValue(value.matchDraws),
+    matchLosses: numberValue(value.matchLosses),
+    matchWins: numberValue(value.matchWins),
+    matchesPlayed: numberValue(value.matchesPlayed),
+    points: numberValue(value.points),
+    rank: numberValue(value.rank),
+    teamId: value.teamId,
+    teamName: text(value.teamName, "Unknown team"),
+    tournamentId: text(value.tournamentId)
+  };
+}
+
+function mapPublicGroups(value: unknown) {
+  return arrayPayload(value).map(mapPublicGroup);
+}
+
+function mapOrganizerGroups(value: unknown) {
+  return arrayPayload(value).map((item) => mapOrganizerGroup(item));
+}
+
+function mapOrganizerGroupTeams(value: unknown) {
+  return arrayPayload(value).map(mapOrganizerGroupTeam);
+}
+
+function mapStandings(value: unknown) {
+  return arrayPayload(value).map(mapStanding);
+}
+
+export async function getPublicGroupsStandingsData(
+  tournamentId: string
+): Promise<PublicGroupsStandingsData> {
+  const [groups, standings] = await Promise.all([
+    getApi<unknown>(`/public/tournaments/${tournamentId}/groups`),
+    getApi<unknown>(`/public/tournaments/${tournamentId}/standings`)
+  ]);
+
+  return {
+    groups: mapPublicGroups(groups),
+    standings: mapStandings(standings)
+  };
+}
+
+export async function listOrganizerTournamentGroups(tournamentId: string) {
+  return mapOrganizerGroups(
+    await getApiAuthenticated<unknown>(`/organizer/tournaments/${tournamentId}/groups`)
+  );
+}
+
+export async function listOrganizerGroupTeams(groupId: string) {
+  return mapOrganizerGroupTeams(
+    await getApiAuthenticated<unknown>(`/organizer/tournament-groups/${groupId}/teams`)
+  );
+}
+
+export async function listOrganizerTournamentGroupsWithTeams(tournamentId: string) {
+  const groups = await listOrganizerTournamentGroups(tournamentId);
+  const teamsByGroup = await Promise.all(
+    groups.map(async (group) => ({
+      groupId: group.id,
+      teams: await listOrganizerGroupTeams(group.id)
+    }))
+  );
+
+  const teamsByGroupId = new Map(teamsByGroup.map((item) => [item.groupId, item.teams]));
+
+  return groups.map((group) => ({
+    ...group,
+    teams: teamsByGroupId.get(group.id) ?? []
+  }));
+}
+
+export async function getOrganizerGroupsData(tournamentId: string): Promise<OrganizerGroupsData> {
+  const groups = await listOrganizerTournamentGroupsWithTeams(tournamentId);
+  let standings: GroupStanding[] = [];
+  let standingsError: string | null = null;
+
+  try {
+    standings = mapStandings(
+      await getApi<unknown>(`/public/tournaments/${tournamentId}/standings`)
+    );
+  } catch (error) {
+    standingsError = error instanceof Error
+      ? error.message
+      : "Organizer standings endpoint is not available for private tournament data.";
+  }
+
+  return {
+    groups,
+    standings,
+    standingsError
+  };
+}
+
+export async function createOrganizerTournamentGroup(
+  tournamentId: string,
+  input: CreateTournamentGroupInput
+) {
+  return mapOrganizerGroup(
+    await postApiAuthenticated<unknown>(`/organizer/tournaments/${tournamentId}/groups`, {
+      name: input.name,
+      sortOrder: input.sortOrder ?? null
+    })
+  );
+}
+
+export async function addTeamToOrganizerGroup(
+  groupId: string,
+  input: AddTeamToGroupInput
+) {
+  return mapOrganizerGroupTeam(
+    await postApiAuthenticated<unknown>(`/organizer/tournament-groups/${groupId}/teams`, {
+      seedNumber: input.seedNumber ?? null,
+      teamId: input.teamId
+    })
+  );
+}
+
+export async function removeTeamFromOrganizerGroup(groupId: string, teamId: string) {
+  await deleteApiAuthenticated<unknown>(`/organizer/tournament-groups/${groupId}/teams/${teamId}`);
+}


### PR DESCRIPTION
Implementiran FE-07 za prikaz skupin in lestvic.

Dodano:
- read-only Groups & Standings prikaz na public strani turnirja (/turnirji/[slug])
- Group Management / Standings Control v organizer detailu
- prikaz skupin, ekip v skupinah in backend-calculated standings
- deep-link iz public tournament strani direktno na organizer Group Management
- empty/loading/error stanja
- 403/404/validation/backend unavailable obdelava
- podprte organizer akcije: Create Group, Add Team, Remove Team, Refresh Groups

Realno povezani backend endpoint-i:
- GET /api/public/tournaments/{tournamentId}/groups
- GET /api/public/tournaments/{tournamentId}/standings
- GET /api/organizer/tournaments/{tournamentId}/groups
- GET /api/organizer/tournament-groups/{groupId}/teams
- POST /api/organizer/tournaments/{tournamentId}/groups
- POST /api/organizer/tournament-groups/{groupId}/teams
- DELETE /api/organizer/tournament-groups/{groupId}/teams/{teamId}

Role behavior:
- visitor/player/captain vidijo samo read-only Groups & Standings
- organizer/admin lahko upravlja skupine znotraj /organizator
- management akcije niso prikazane na public strani

Unsupported funkcije ostajajo disabled placeholderji:
- auto-generate groups
- bulk seed teams
- recalculate standings
- export standings
- manual tie-break override
- advanced tie-break editor

Dodatno:
- FE-06 je poenostavljen kot organizer/admin operativni nadzor
- ni dodanih posebnih referee/analyst/score-reporter login vlog
- ostane obstoječi role model: public, player, captain, organizer, admin

Ni bilo sprememb na:
- backendu
- AppShell/sidebar/topbar/navigation
- auth/register/profile/route-access

Preverjeno:
- npm.cmd run lint
- npm.cmd run typecheck
- npm.cmd run build